### PR TITLE
[unitaryhack] Adding a post_build method to Element to avoid calls to super().build() when constructing chips.

### DIFF
--- a/docs/user_guide/python_workflow.rst
+++ b/docs/user_guide/python_workflow.rst
@@ -196,9 +196,6 @@ element created in the previous section into a new chip::
             self.insert_cell(cross_cell, pya.DTrans(half_width + 2000, half_width + 2000))
             self.insert_cell(cross_cell, pya.DTrans(half_width + 2000, half_width - 2000))
 
-            # Call the Chip-class build-method to produce the chip frame and possible ground plane grid.
-            super().build()
-
 This code can be copied to a new Python-file ``new_chip1.py`` in the
 ``klayout_package/python/kqcircuits/chips`` folder to make it visible in the
 KQCircuits chip library.
@@ -254,8 +251,6 @@ using refpoints::
                     cap_refpoints["port_b"],
                 ], 0),
             )
-
-            super().build()
 
 
 How to use the points once they exist? Several styles have evolved:

--- a/klayout_package/python/kqcircuits/chips/airbridge_crossings.py
+++ b/klayout_package/python/kqcircuits/chips/airbridge_crossings.py
@@ -45,7 +45,6 @@ class AirbridgeCrossings(Chip):
         launchers = self.produce_launchers("SMA8")
         self._produce_transmission_lines(launchers)
         self._produce_mechanical_test_array()
-        super().build()
 
     def _produce_transmission_lines(self, launchers):
 

--- a/klayout_package/python/kqcircuits/chips/airbridge_dc_test.py
+++ b/klayout_package/python/kqcircuits/chips/airbridge_dc_test.py
@@ -42,8 +42,6 @@ class AirbridgeDcTest(Chip):
         n_ab, test_id = self._produce_tests_within_box(pya.DBox(d1, d2, chip_size - d1, chip_size - d2), n_ab, test_id)
         n_ab, test_id = self._produce_tests_within_box(pya.DBox(d2, d1, chip_size - d2, d2), n_ab, test_id)
 
-        super().build()
-
     def _produce_tests_within_box(self, box, n_ab, test_id):
 
         num_horizontal = int(box.width()//self.test_width)

--- a/klayout_package/python/kqcircuits/chips/chip.py
+++ b/klayout_package/python/kqcircuits/chips/chip.py
@@ -223,7 +223,7 @@ class Chip(Element):
         if self.with_gnd_tsvs:
             self._produce_ground_tsvs(face_id=0)
 
-    def build(self):
+    def post_build(self):
         self.produce_structures()
         if self.with_grid:
             self.produce_ground_grid()

--- a/klayout_package/python/kqcircuits/chips/dc_test.py
+++ b/klayout_package/python/kqcircuits/chips/dc_test.py
@@ -25,4 +25,3 @@ class DcTest(Chip):
     def build(self):
 
         self.produce_launchers("DC24")
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/demo.py
+++ b/klayout_package/python/kqcircuits/chips/demo.py
@@ -69,8 +69,6 @@ class Demo(Chip):
         self.produce_probelines()
         self.produce_junction_tests()
 
-        super().build()
-
     def produce_qubits(self):
         dist_x = 3220  # x-distance from chip edge
         dist_y = 3000  # y-distance from chip edge

--- a/klayout_package/python/kqcircuits/chips/empty.py
+++ b/klayout_package/python/kqcircuits/chips/empty.py
@@ -48,4 +48,3 @@ class Empty(Chip):
         empty_area = self.make_empty_area()
         self.cell.shapes(self.get_layer("base_metal_gap_wo_grid")).insert(empty_area)
         self.cell.shapes(self.get_layer("ground_grid_avoidance")).insert(empty_area)
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/junction_test.py
+++ b/klayout_package/python/kqcircuits/chips/junction_test.py
@@ -77,5 +77,3 @@ class JunctionTest(Chip):
 
         result = reg1 - reg2
         self.cell.shapes(self.get_layer("base_metal_gap_wo_grid")).insert(result)
-
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/junction_test2.py
+++ b/klayout_package/python/kqcircuits/chips/junction_test2.py
@@ -94,5 +94,3 @@ class JunctionTest2(Chip):
                                 )
             self.insert_cell(cell, pya.DTrans(0, False, array_coordinates[0], array_coordinates[1]),
                              name + "_{}".format(j+1))
-
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/launchers.py
+++ b/klayout_package/python/kqcircuits/chips/launchers.py
@@ -30,4 +30,3 @@ class Launchers(Chip):
 
     def build(self):
         self.produce_launchers(self.sampleholder_type)
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/lithography_test.py
+++ b/klayout_package/python/kqcircuits/chips/lithography_test.py
@@ -52,8 +52,6 @@ class LithographyTest(Chip):
         self.insert_cell(cell_diagonal_2, pya.DCplxTrans(1, 0, False, 3100, 1500))
         self.insert_cell(cell_diagonal_2, pya.DCplxTrans(1, 0, False, 6100, 1500))
 
-        super().build()
-
     def create_pattern(self, num_stripes, length, min_width, max_width, step, spacing, face_id):
         first_stripes_width = 2 * num_stripes * min_width
         cell_horizontal = self.layout.create_cell("Stripes")

--- a/klayout_package/python/kqcircuits/chips/multi_face/crossing_twoface.py
+++ b/klayout_package/python/kqcircuits/chips/multi_face/crossing_twoface.py
@@ -41,7 +41,6 @@ class CrossingTwoface(MultiFace):
     def build(self):
         launchers = self.produce_launchers("SMA8")
         self._produce_transmission_lines(launchers)
-        super().build()
 
     def _produce_transmission_lines(self, launchers):
         distance = 700

--- a/klayout_package/python/kqcircuits/chips/multi_face/daisy_woven.py
+++ b/klayout_package/python/kqcircuits/chips/multi_face/daisy_woven.py
@@ -33,7 +33,6 @@ class DaisyWoven(MultiFace):
 
     def build(self):
         self._produce_daisy_face("Daisy_woven")
-        super().build()
 
     def _produce_daisy_face(self, cell_name):
         # first create chip frame to change polarity of manual drawing

--- a/klayout_package/python/kqcircuits/chips/multi_face/demo_twoface.py
+++ b/klayout_package/python/kqcircuits/chips/multi_face/demo_twoface.py
@@ -64,8 +64,6 @@ class DemoTwoface(MultiFace):
         self.produce_readout_structures()
         self.produce_probelines()
 
-        super().build()
-
     def produce_qubits(self):
         dist_x = 2000  # distance from bottom chip edge
         dist_y = 3200

--- a/klayout_package/python/kqcircuits/chips/multi_face/lithography_test_twoface.py
+++ b/klayout_package/python/kqcircuits/chips/multi_face/lithography_test_twoface.py
@@ -65,5 +65,3 @@ class LithographyTestTwoface(MultiFace):
         self.insert_cell(cell_vertical_4, pya.DCplxTrans(1, 0, False, 5000, 4000) * pya.DCplxTrans.M90)
         self.insert_cell(cell_diagonal_3, pya.DCplxTrans(1, 0, False, 7500, 1800) * pya.DCplxTrans.M90)
         self.insert_cell(cell_diagonal_4, pya.DCplxTrans(1, 0, False, 6200, 1800) * pya.DCplxTrans.M90)
-
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/multi_face/quality_factor_twoface.py
+++ b/klayout_package/python/kqcircuits/chips/multi_face/quality_factor_twoface.py
@@ -61,9 +61,6 @@ class QualityFactorTwoface(MultiFace):
     def build(self):
         self._produce_resonators()
 
-        # Basis chip with possibly ground plane grid
-        super().build()
-
     def _produce_resonators(self):
         # Interpretation of parameter lists
         res_lengths = [float(foo) for foo in self.res_lengths]

--- a/klayout_package/python/kqcircuits/chips/quality_factor.py
+++ b/klayout_package/python/kqcircuits/chips/quality_factor.py
@@ -173,6 +173,3 @@ class QualityFactor(Chip):
             "path": pya.DPath(points_fl + points_fl_end, 1),
             "term2": 0
         }})
-
-        # Basis chip with possibly ground plane grid
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/sample_holder_test.py
+++ b/klayout_package/python/kqcircuits/chips/sample_holder_test.py
@@ -62,5 +62,3 @@ class SampleHolderTest(Chip):
         for i, j in zip(range(2 * nr_pads_per_side + 1, 3 * nr_pads_per_side + 1),
                         range(4 * nr_pads_per_side, 3 * nr_pads_per_side, -1)):
             _produce_waveguide(i, j, 1200)
-
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/shaping.py
+++ b/klayout_package/python/kqcircuits/chips/shaping.py
@@ -364,6 +364,3 @@ class Shaping(Chip):
                 launchers["SW"][0] + pya.DVector(0, 0),
             ], 1),
         )
-
-        # chip frame and possibly ground plane grid
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/simple.py
+++ b/klayout_package/python/kqcircuits/chips/simple.py
@@ -63,6 +63,3 @@ class Simple(Chip):
         refs = self.refpoints
         self.insert_cell(WaveguideCoplanar, path=pya.DPath([tcross_refs["port_bottom"], refs["C2_port_a"]], 1))
         self.insert_cell(WaveguideCoplanar, path=pya.DPath([refs["C2_port_b"], launchers["SE"][0]], 1))
-
-        # chip frame and possibly ground plane grid
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/single_xmons.py
+++ b/klayout_package/python/kqcircuits/chips/single_xmons.py
@@ -77,7 +77,6 @@ class SingleXmons(Chip):
 
         self._produce_readout_resonators()
         self._produce_chargelines()
-        super().build()
 
     def _produce_waveguide(self, path, term2=0, turn_radius=None):
         """Produces a coplanar waveguide that follows the given path.

--- a/klayout_package/python/kqcircuits/chips/stripes.py
+++ b/klayout_package/python/kqcircuits/chips/stripes.py
@@ -128,5 +128,3 @@ class Stripes(Chip):
 
         result = reg1 - reg2
         self.cell.shapes(self.get_layer("base_metal_gap_wo_grid")).insert(result)
-
-        super().build()

--- a/klayout_package/python/kqcircuits/chips/tsv_test.py
+++ b/klayout_package/python/kqcircuits/chips/tsv_test.py
@@ -52,7 +52,6 @@ class TsvTest(Chip):
                              pitch=self.metrology_pitch + 2 * min_spacing)
         self.create_xsection(position=pya.DPoint(8750, 1250), array_form=[6, 6], pitch=self.metrology_pitch + 2.5 *
                                                                                        min_spacing)
-        super().build()
 
     def create_xsection(self, position, array_form, pitch):
         tsv_unit = self.add_element(Tsv)

--- a/klayout_package/python/kqcircuits/chips/xmons_direct_coupling.py
+++ b/klayout_package/python/kqcircuits/chips/xmons_direct_coupling.py
@@ -279,5 +279,3 @@ class XMonsDirectCoupling(Chip):
             Node(self.refpoints["QB3_port_flux_corner"], n_bridges=30),
             Node(self.refpoints["QB3_port_flux"])
         ])
-
-        super().build()

--- a/klayout_package/python/kqcircuits/elements/element.py
+++ b/klayout_package/python/kqcircuits/elements/element.py
@@ -298,12 +298,17 @@ class Element(pya.PCellDeclarationHelper):
 
         self.build()
 
+        self.post_build()
+
         for name, refpoint in self.refpoints.items():
             text = pya.DText(name, refpoint.x, refpoint.y)
             self.cell.shapes(self.get_layer("refpoints")).insert(text)
 
     def build(self):
         """Child classes re-define this method to build the PCell."""
+
+    def post_build(self):
+        """Child classes re-define this method for post-build operations"""
 
     def display_text_impl(self):
         if self.display_name:

--- a/klayout_package/python/kqcircuits/util/layout_to_code.py
+++ b/klayout_package/python/kqcircuits/util/layout_to_code.py
@@ -295,7 +295,6 @@ def convert_cells_to_code(top_cell, print_waveguides_as_composite=False, add_ins
 
     if output_format == "insert_cell+chip":
         full_code = start_code + textwrap.indent(instances_code, "        ") + "\n"
-        full_code += textwrap.indent("super().build()", "        ")
     else:
         full_code = start_code + instances_code
 


### PR DESCRIPTION
Fixes #12 by following the instructions provided in the issue:

- A `post_build` method has been added to the `Element` class which is called in `Element.produce_impl` following a call to `build`.
- The `Chip.build` method has been renamed to `Chip.post_build`.
- All `super().build()` calls have been removed from chips as well as the associated documentation for implementing new chips.

All tests pass locally, so chips should continue to be constructed properly following these changes.