### PR TITLE
Write project results without Slurm for Elmer

### DIFF
--- a/klayout_package/python/kqcircuits/simulations/export/elmer/elmer_export.py
+++ b/klayout_package/python/kqcircuits/simulations/export/elmer/elmer_export.py
@@ -251,6 +251,13 @@ def export_elmer_script(json_filenames, path: Path, workflow=None, file_prefix='
                         Path(json_filename).relative_to(path),
                         python_executable)
                     )
+                    file.write('echo "Simulation {}/{} write results json"\n'.format(i + 1, len(json_filenames)))
+                    file.write('{2} "{0}" "{1}" --write-project-results 2>&1 >> '\
+                            '"{1}_write_project_results.log"\n'.format(
+                        script_file,
+                        Path(json_filename).relative_to(path),
+                        python_executable)
+                    )
 
             # change permission
             os.chmod(script_filename, os.stat(script_filename).st_mode | stat.S_IEXEC)


### PR DESCRIPTION
Always write project results for Elmer simulations when running only `simulation.sh`

Closes #28