### PR TITLE
Use `importlib.util` for better support

### DIFF
--- a/klayout_package/python/scripts/simulations/elmer/scripts/simple_workload_manager.py
+++ b/klayout_package/python/scripts/simulations/elmer/scripts/simple_workload_manager.py
@@ -16,7 +16,7 @@
 # for individuals (meetiqm.com/developers/clas/individual) and organizations (meetiqm.com/developers/clas/organization).
 
 import os
-import importlib
+import importlib.util
 import argparse
 import subprocess
 


### PR DESCRIPTION
Fix user reported bug for certain environments by being more specific in imports

Closes #38 