### PR TITLE
Add official Discord link to Readme and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,14 @@ API.
    :target: https://github.com/iqm-finland/KQCircuits/releases/
    :alt: Latest version
 
+.. image:: https://img.shields.io/discord/1054371222420471818?label=Discord&color=7289da&logo=discord&logoColor=white
+   :target: https://discord.gg/4wP8WAeWuJ
+   :alt: Official Discord
+
 .. image:: https://img.shields.io/badge/click-for%20documentation%20%F0%9F%93%92-lightgrey
    :target: https://iqm-finland.github.io/KQCircuits/index.html
    :alt: Click for documentation
+
 
 
 ----
@@ -43,7 +48,7 @@ export a set of files for a mask as needed for QPU fabrication.
    :alt: QPU design workflow
    :width: 700
 
-⠀
+
 
 .. image:: /docs/images/readme/single_xmons_chip_3.png
    :alt: Example layout
@@ -175,8 +180,7 @@ Support
 
 If you have any questions, problems or ideas related to KQCircuits, please start
 a
-`discussion in GitHub <https://github.com/iqm-finland/KQCircuits/discussions>`__
-or create a `GitHub issue <https://github.com/iqm-finland/KQCircuits/issues>`__.
+`discussion in GitHub <https://github.com/iqm-finland/KQCircuits/discussions>`__, create a `GitHub issue <https://github.com/iqm-finland/KQCircuits/issues>`__, or ask in the `KQCircuits Discord <https://discord.gg/4wP8WAeWuJ>`__.
 
 Contributing
 ------------

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,7 +1,10 @@
 Support
 -------
 
+.. image:: https://img.shields.io/discord/1054371222420471818?label=Discord&color=7289da&logo=discord&logoColor=white
+   :target: https://discord.gg/4wP8WAeWuJ
+   :alt: Official Discord
+
 If you have any questions, problems or ideas related to KQCircuits, please start
 a
-`discussion in GitHub <https://github.com/iqm-finland/KQCircuits/discussions>`__
-or create a `GitHub issue <https://github.com/iqm-finland/KQCircuits/issues>`__.
+`discussion in GitHub <https://github.com/iqm-finland/KQCircuits/discussions>`__, create a `GitHub issue <https://github.com/iqm-finland/KQCircuits/issues>`__, or ask in the `KQCircuits Discord <https://discord.gg/4wP8WAeWuJ>`__.


### PR DESCRIPTION
This PR adds a badge and a link to the official KQCircuits in the Readme and docs

![https://discord.gg/4wP8WAeWuJ](https://img.shields.io/discord/1054371222420471818?label=Discord&color=7289da&logo=discord&logoColor=white)

Closes #40