### PR TITLE
Fix Meander size in WaveguideComposite

### DIFF
--- a/klayout_package/python/kqcircuits/elements/waveguide_composite.py
+++ b/klayout_package/python/kqcircuits/elements/waveguide_composite.py
@@ -729,8 +729,9 @@ class WaveguideComposite(Element):
                     else:
                         meander_len -= start_len + (self._nodes[n1-1].position - turn_start).length()
 
+                params = {**node1.params, "a": self.a, "b": self.b}
                 cell_inst, _ = self.insert_cell(Meander, start=[meander_start.x, meander_start.y],
-                                                end=[meander_end.x, meander_end.y], length=meander_len, **node1.params)
+                                                end=[meander_end.x, meander_end.y], length=meander_len, **params)
                 cell_inst.set_property("waveguide_composite_node_index", end_index)
                 wg_points = point0 + points[p0:p1] + ([] if start_len < 1e-4 else [meander_start])
                 self._insert_wg_cell(wg_points, n0, n1)


### PR DESCRIPTION
by passing starting a/b to it.

Fixes #37

![image](https://user-images.githubusercontent.com/125267946/234314201-fbe05b6b-3473-4aa7-ab33-62d385947e30.png)
