### PR TITLE
Add parameter names to markers in documentation

### DIFF
--- a/docs/developer/documentation.rst
+++ b/docs/developer/documentation.rst
@@ -18,7 +18,10 @@ these are in the :git_url:`docs/sphinxext` folder. Also the
 image of every PCell into the pcell_images directory, these get included in the
 API documentation.
 
-The docstring of PCell classes may contain a ``.. MARKERS_FOR_PNG x,y x2,y2,
-...`` line that will annotate the generated .png image with "rulers"
-documenting the important dimensions of the design. The rulers are placed
-according to KLayout's rules going through the specified ``x, y`` coordinates.
+The docstring of PCell classes may contain a ``.. MARKERS_FOR_PNG x,y x_2,y_2, ...`` line that will
+annotate the generated .png image with "rulers" documenting the important dimensions of the design.
+The rulers are placed according to KLayout's rules for rulers going through a specified point.
+These annotations should preferably also have the name of the parameter controlling the illustrated
+dimensions, like ``.. MARKERS_FOR_PNG x,y,param_name``. Some times KLayout's automatic ruler
+placement is not satisfactory in this case the user may specify both starting and ending points of
+the ruler ``.. MARKERS_FOR_PNG x,y,x2,y2[,param_name]``.

--- a/docs/pcell2png.py
+++ b/docs/pcell2png.py
@@ -38,7 +38,8 @@ from kqcircuits.pya_resolver import pya
 
 
 # Ruler places are specified as space delimited x,y coordinate pairs after a "MARKERS_FOR_PNG" tag.
-# Ruler places can also be added manually using x1,y1,x2,y2 format.
+# The last argument may be a param name, i.e. x,y,name. Ruler places can also be added manually
+# using x1,y1,x2,y2[,name] format.
 def add_rulers(cls, view):
     if not cls.__doc__:
         return
@@ -47,18 +48,24 @@ def add_rulers(cls, view):
     if markers:
         rulers += markers[0].split()
 
-    #Check for autoruler in x,y format or manual ruler in x1,y1,x2,y2 format
+    #Check for autoruler in x,y[,name] format or manual ruler in x1,y1,x2,y2[,name] format
     for ruler in rulers:
-        markers = [float(x) for x in ruler.split(',')]
+        markers = [x for x in ruler.split(',')]
+
+        pname = ''
+        if len(markers) in (3, 5):
+            pname = markers.pop(-1) + "\n"
+        markers = [float(x) for x in markers]
+
         if len(markers) == 2:
             ant = view.layout_view.create_measure_ruler(pya.DPoint(markers[0], markers[1]))
-            ant.fmt = "$(sprintf('%.1f',D))"
+            ant.fmt = f"$(sprintf('{pname}%.1f',D))"
         elif len(markers) == 4:
             ant = pya.Annotation()
             ant.p1 = pya.DPoint(markers[0],markers[1])
             ant.p2 = pya.DPoint(markers[2],markers[3])
             ant.style = pya.Annotation.StyleRuler
-            ant.fmt = "$(sprintf('%.1f',D))"
+            ant.fmt = f"$(sprintf('{pname}%.1f',D))"
             view.layout_view.insert_annotation(ant)
 
 # Get arguments from command line, if not already processed by KLayout.

--- a/klayout_package/python/kqcircuits/elements/finger_capacitor_square.py
+++ b/klayout_package/python/kqcircuits/elements/finger_capacitor_square.py
@@ -29,7 +29,7 @@ class FingerCapacitorSquare(Element):
     Two ports with reference points. The arm leading to the finger has the same width as fingers. The feedline has
     the same length as the width of the ground gap around the coupler.
 
-    .. MARKERS_FOR_PNG 20,-10 0,17 0,5
+    .. MARKERS_FOR_PNG 20,-10,ground_padding 0,17,finger_width 0,5,finger_gap
     """
 
     a2 = Param(pdt.TypeDouble, "Width of center conductor on the other end", -1, unit="μm",

--- a/klayout_package/python/kqcircuits/elements/waveguide_coplanar_taper.py
+++ b/klayout_package/python/kqcircuits/elements/waveguide_coplanar_taper.py
@@ -30,7 +30,7 @@ from kqcircuits.elements.waveguide_coplanar_straight import WaveguideCoplanarStr
 class WaveguideCoplanarTaper(Element):
     """The PCell declaration of a taper segment of a coplanar waveguide.
 
-    .. MARKERS_FOR_PNG 0,0,31.2,0 0,5,0,-5 31.2,-10,31.2,10
+    .. MARKERS_FOR_PNG 0,0,31.2,0,taper_length 0,5,0,-5,a 31.2,-10,31.2,10,a2
     """
 
     taper_length = Param(pdt.TypeDouble, "Taper length", 10 * math.pi, unit="μm")


### PR DESCRIPTION
Markers for annotating auto-generated images in documentation now may have one more argument, the name of the parameter. This will also be shown in the image.

Fix #53