### PR TITLE
Fix parameter name verification error

### DIFF
--- a/klayout_package/python/kqcircuits/util/parameters.py
+++ b/klayout_package/python/kqcircuits/util/parameters.py
@@ -39,7 +39,7 @@ def add_parameters_from(cls, /, *param_names, **param_with_default_value):
         param_names = param_names[1:]
         invert = True
 
-    unknown = (set(param_names) or set(param_with_default_value.keys())) - set(cls.get_schema().keys())
+    unknown = (set(param_names) | set(param_with_default_value.keys())) - set(cls.get_schema().keys())
     if unknown:
         raise ValueError(f"Parameter(s) {unknown} not available in '{cls.__name__}'")
 


### PR DESCRIPTION
in @add_parameter_from. 

This PR fixes a small logic error in checking parameter names. It was allowed to specify a non-existant (mistyped) parameter  name to change a default value and leaving the developer wondering why the new default is not used.