### PR TITLE
Reload existing PCells without closing KLayout

### DIFF
--- a/klayout_package/python/scripts/macros/0system/0reload.lym
+++ b/klayout_package/python/scripts/macros/0system/0reload.lym
@@ -37,6 +37,10 @@ Note that this does not reload the ``defaults`` file.
 """
 
 from kqcircuits.util.library_helper import load_libraries
+from kqcircuits.util.layout_to_code import extract_pcell_data_from_views, restore_pcells_to_views
+
+views = extract_pcell_data_from_views()
 load_libraries(flush=True)
+restore_pcells_to_views(views)
 </text>
 </klayout-macro>


### PR DESCRIPTION
The "KQCircuits -> Reload libraries" command apart from reloading the libraries also saves and re-creates all PCells in every view using the updated code but retaining all the parameter changes of the user.

Fix #14