### PR TITLE
Removal of 'Edit on Github' link for API pages of KQC documentation - Fixes #92

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,0 +1,7 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% if not meta or meta.get('github_url') != 'hide' %}
+{{ super() }}
+{% endif %}
+{% endblock %}

--- a/docs/templates/apidoc/module.rst_t
+++ b/docs/templates/apidoc/module.rst_t
@@ -1,3 +1,6 @@
+:github_url: hide
+{{"\n"}}
+
 {%- if show_headings %}
 {{- basename | e | heading }}
 

--- a/docs/templates/apidoc/package.rst_t
+++ b/docs/templates/apidoc/package.rst_t
@@ -1,3 +1,6 @@
+:github_url: hide
+{{"\n"}}
+
 {%- macro automodule(modname, options) -%}
 .. automodule:: {{ modname }}
 {%- for option in options %}

--- a/docs/templates/apidoc/toc.rst_t
+++ b/docs/templates/apidoc/toc.rst_t
@@ -1,3 +1,6 @@
+:github_url: hide
+{{"\n"}}
+
 {{ header | heading }}
 
 .. toctree::


### PR DESCRIPTION
### ISSUE
The API documentation pages are automatically generated by sphinx. Despite not having a documentation "source" the same way hand-written documentation pages have, sphinx still renders a link to the associated non-existent repo page.  
Such link has to be removed only for the API-related documentation pages.

### SOLUTION

Added  docs/_templates/breadcrumbs.html, as suggested in [this post](https://github.com/sphinx-doc/sphinx/issues/2386#issuecomment-478403897), in order to overwrite the custom sphinx theme.

**Changes:** 
Whenever `:github_url: hide` metadata is added at the top of a .rst file, breadcrumbs are not rendered. 
`:github_url: hide` has been added to the top of each template file responsible for the generation of the API docs.    
A new line has been forced by adding `{{"\n"}}` to avoid the added static text interfering with header generation. 

Fixes #92 
