### PR TITLE
Fix "Reload Libraries macro issues"

### DIFF
--- a/klayout_package/python/kqcircuits/util/layout_to_code.py
+++ b/klayout_package/python/kqcircuits/util/layout_to_code.py
@@ -362,7 +362,7 @@ def extract_pcell_data_from_views():
 
     Returns: a tuple (views, instances) where
         views: a list of lists. Each element corresponds to a view in KLayout and it is a list of
-        ``(type, location, parameters)`` tuples. These tuples completely describe the type, position 
+        ``(type, location, parameters)`` tuples. These tuples completely describe the type, position
         and parameters of a single PCell in the "Top Cell" of this view.
         instances: flattened list of all instances of KQCircuits PCells found.
     """

--- a/klayout_package/python/kqcircuits/util/layout_to_code.py
+++ b/klayout_package/python/kqcircuits/util/layout_to_code.py
@@ -16,7 +16,6 @@
 # Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
 # and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
 
-from math import isinf
 from sys import float_info
 import textwrap
 

--- a/klayout_package/python/kqcircuits/util/layout_to_code.py
+++ b/klayout_package/python/kqcircuits/util/layout_to_code.py
@@ -357,8 +357,19 @@ def get_node_params(node: Node):
     return node_params, elem
 
 
+def remove_kqc_pcells():
+    """Remove all KQCircuits PCells."""
+
+    main_window = pya.Application.instance().main_window()
+    for vid in range(main_window.views()):
+        top_cell = main_window.view(vid).active_cellview().cell
+        for inst in top_cell.each_inst():
+            if isinstance(inst.pcell_declaration(), Element):
+                inst.delete()
+
+
 def extract_pcell_data_from_views():
-    """Remove all KQCircuits PCells and return their data.
+    """Iterate over all KQCircuits PCells and return their data.
 
     Returns: A list of lists. Each element corresponds to a view in KLayout and it is a list of
         ``(type, location, parameters)`` tuples. These tuples completely describe the type, position and
@@ -379,7 +390,6 @@ def extract_pcell_data_from_views():
                     if params[k] == v.default:
                         del params[k]
                 pcells.append((pc.__class__, inst.dtrans, params))
-                inst.delete()
         views.append(pcells)
 
     return views

--- a/klayout_package/python/kqcircuits/util/layout_to_code.py
+++ b/klayout_package/python/kqcircuits/util/layout_to_code.py
@@ -357,26 +357,18 @@ def get_node_params(node: Node):
     return node_params, elem
 
 
-def remove_kqc_pcells():
-    """Remove all KQCircuits PCells."""
-
-    main_window = pya.Application.instance().main_window()
-    for vid in range(main_window.views()):
-        top_cell = main_window.view(vid).active_cellview().cell
-        for inst in top_cell.each_inst():
-            if isinstance(inst.pcell_declaration(), Element):
-                inst.delete()
-
-
 def extract_pcell_data_from_views():
-    """Iterate over all KQCircuits PCells and return their data.
+    """Iterate over all KQCircuits PCells and return their data and instances.
 
-    Returns: A list of lists. Each element corresponds to a view in KLayout and it is a list of
-        ``(type, location, parameters)`` tuples. These tuples completely describe the type, position and
-        parameters of a single PCell in the "Top Cell" of this view.
+    Returns: a tuple (views, instances) where
+        views: a list of lists. Each element corresponds to a view in KLayout and it is a list of
+        ``(type, location, parameters)`` tuples. These tuples completely describe the type, position 
+        and parameters of a single PCell in the "Top Cell" of this view.
+        instances: flattened list of all instances of KQCircuits PCells found.
     """
 
     views = []
+    instances = []
     main_window = pya.Application.instance().main_window()
     for vid in range(main_window.views()):
         top_cell = main_window.view(vid).active_cellview().cell
@@ -384,6 +376,7 @@ def extract_pcell_data_from_views():
         for inst in top_cell.each_inst():
             pc = inst.pcell_declaration()
             if isinstance(pc, Element):
+                instances.append(inst)
                 params = inst.pcell_parameters_by_name()
                 def_params = pc.__class__.get_schema()
                 for k, v in def_params.items():
@@ -392,7 +385,7 @@ def extract_pcell_data_from_views():
                 pcells.append((pc.__class__, inst.dtrans, params))
         views.append(pcells)
 
-    return views
+    return views, instances
 
 
 def restore_pcells_to_views(views):

--- a/klayout_package/python/kqcircuits/util/layout_to_code.py
+++ b/klayout_package/python/kqcircuits/util/layout_to_code.py
@@ -16,6 +16,7 @@
 # Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
 # and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
 
+from math import isinf
 from sys import float_info
 import textwrap
 
@@ -358,7 +359,7 @@ def get_node_params(node: Node):
 
 
 def extract_pcell_data_from_views():
-    """Remove all PCells and return their data.
+    """Remove all KQCircuits PCells and return their data.
 
     Returns: A list of lists. Each element corresponds to a view in KLayout and it is a list of
         ``(type, location, parameters)`` tuples. These tuples completely describe the type, position and
@@ -372,7 +373,7 @@ def extract_pcell_data_from_views():
         pcells = []
         for inst in top_cell.each_inst():
             pc = inst.pcell_declaration()
-            if pc:
+            if isinstance(pc, Element):
                 params = inst.pcell_parameters_by_name()
                 def_params = pc.__class__.get_schema()
                 for k, v in def_params.items():

--- a/klayout_package/python/kqcircuits/util/library_helper.py
+++ b/klayout_package/python/kqcircuits/util/library_helper.py
@@ -84,6 +84,8 @@ def load_libraries(flush=False, path=""):
     Returns:
          A dictionary of libraries that have been loaded, keys are library names and values are libraries.
     """
+    # Try reloading all pcells before deleting libraries, otherwise classes are lost in case of errors
+    all_pcell_classes = _get_all_pcell_classes(flush, path)
 
     if flush:
         delete_all_libraries()
@@ -95,7 +97,7 @@ def load_libraries(flush=False, path=""):
             if lib_path == path:
                 return {key: value[0] for key, value in _kqc_libraries.items()}
 
-    for cls in _get_all_pcell_classes(flush, path):
+    for cls in all_pcell_classes:
 
         library_name = cls.LIBRARY_NAME
         library_path = cls.LIBRARY_PATH

--- a/klayout_package/python/scripts/macros/0system/0reload.lym
+++ b/klayout_package/python/scripts/macros/0system/0reload.lym
@@ -38,14 +38,15 @@ Note that this does not reload the ``defaults`` file.
 """
 
 from kqcircuits.util.library_helper import load_libraries
-from kqcircuits.util.layout_to_code import remove_kqc_pcells, extract_pcell_data_from_views, restore_pcells_to_views
+from kqcircuits.util.layout_to_code import extract_pcell_data_from_views, restore_pcells_to_views
 
-views = extract_pcell_data_from_views()
+views, instances = extract_pcell_data_from_views()
 try:
   load_libraries(flush=True)
 except:
   raise RuntimeError("Failed to reload KQCircuits libraries, keeping current views.")
-remove_kqc_pcells()
+for inst in instances:
+  inst.delete()
 restore_pcells_to_views(views)
 </text>
 </klayout-macro>

--- a/klayout_package/python/scripts/macros/0system/0reload.lym
+++ b/klayout_package/python/scripts/macros/0system/0reload.lym
@@ -41,12 +41,14 @@ from kqcircuits.util.library_helper import load_libraries
 from kqcircuits.util.layout_to_code import extract_pcell_data_from_views, restore_pcells_to_views
 
 views, instances = extract_pcell_data_from_views()
-try:
-  load_libraries(flush=True)
-except:
-  raise RuntimeError("Failed to reload KQCircuits libraries, keeping current views.")
 for inst in instances:
   inst.delete()
+try:
+  load_libraries(flush=True)
+except Exception as e:
+  restore_pcells_to_views(views)
+  raise RuntimeError("Failed to reload KQCircuits libraries and redraw cells." +
+    f"\nThe following exception was raised: \n{type(e).__name__}: {e}")
 restore_pcells_to_views(views)
 </text>
 </klayout-macro>

--- a/klayout_package/python/scripts/macros/0system/0reload.lym
+++ b/klayout_package/python/scripts/macros/0system/0reload.lym
@@ -41,7 +41,11 @@ from kqcircuits.util.library_helper import load_libraries
 from kqcircuits.util.layout_to_code import extract_pcell_data_from_views, restore_pcells_to_views
 
 views = extract_pcell_data_from_views()
-load_libraries(flush=True)
-restore_pcells_to_views(views)
+try:
+  load_libraries(flush=True)
+  restore_pcells_to_views(views)
+except:
+  restore_pcells_to_views(views)
+  raise RuntimeError("Failed to reload all KQCircuits libraries, restoring current view.")
 </text>
 </klayout-macro>

--- a/klayout_package/python/scripts/macros/0system/0reload.lym
+++ b/klayout_package/python/scripts/macros/0system/0reload.lym
@@ -38,14 +38,14 @@ Note that this does not reload the ``defaults`` file.
 """
 
 from kqcircuits.util.library_helper import load_libraries
-from kqcircuits.util.layout_to_code import extract_pcell_data_from_views, restore_pcells_to_views
+from kqcircuits.util.layout_to_code import remove_kqc_pcells, extract_pcell_data_from_views, restore_pcells_to_views
 
 views = extract_pcell_data_from_views()
 try:
   load_libraries(flush=True)
-  restore_pcells_to_views(views)
 except:
-  restore_pcells_to_views(views)
-  raise RuntimeError("Failed to reload all KQCircuits libraries, restoring current view.")
+  raise RuntimeError("Failed to reload KQCircuits libraries, keeping current views.")
+remove_kqc_pcells()
+restore_pcells_to_views(views)
 </text>
 </klayout-macro>


### PR DESCRIPTION
This pull request addresses issue #89.
To start, I implemented a basic solution by making ```extract_pcell_data_from_views``` work only with instances of ```Element``` and by restoring the view in case of an exception when reloading the libraries.