### PR TITLE
General rationale and first viable test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ dmypy.json
 # Additions
 # --------------------------------------------------------------------------------
 
+# VSCode local settings
+.vscode
+
 # JetBrains IDEs
 .idea/
 

--- a/klayout_package/python/kqcircuits/util/export_helper.py
+++ b/klayout_package/python/kqcircuits/util/export_helper.py
@@ -490,3 +490,26 @@ def export_drc_report(name, path, drc_script):
         )
     except subprocess.CalledProcessError as e:
         logging.error(e.output)
+
+
+def setup_paraview_macro(**kwargs):
+    """Undertakes the foundational set up of paraview's macro, essentially writing all kwargs to the file."""
+
+    # Key paths
+    paraview_macro_path = Path("klayout_package/python/scripts/simulations/post_process/paraview_macro.py")
+
+    # Write kwargs to macro
+    with open(paraview_macro_path, "r") as f:
+        lines = f.readlines()
+        f.close
+
+    new_lines = []
+    for line in lines:
+        if line.strip().startswith("kwargs ="):
+            new_lines.append("".join(["kwargs = ", str(kwargs), "\n"]))
+        else:
+            new_lines.append(line)
+
+    with open(paraview_macro_path, "w") as f:
+        f.writelines(new_lines)
+        f.close

--- a/klayout_package/python/scripts/simulations/concentrictransmon_couplings_sim.py
+++ b/klayout_package/python/scripts/simulations/concentrictransmon_couplings_sim.py
@@ -35,7 +35,10 @@ from kqcircuits.util.export_helper import (
     get_active_or_new_layout,
     open_with_klayout_or_default_application,
 )
+
 from kqcircuits.simulations.single_element_simulation import get_single_element_sim_class
+from kqcircuits.util.export_helper import setup_paraview_macro
+
 
 # Prepare output directory
 dir_path = create_or_empty_tmp_directory(Path(__file__).stem + "_output")
@@ -73,7 +76,7 @@ elmer_export_parameters = {
         "run_gmsh_gui": False,  # open gmsh gui after meshing
         "run_elmergrid": True,
         "run_elmer": True,
-        "run_paraview": False,  # opens results in ParaView after finishing
+        "run_paraview": True,  # opens results in ParaView after finishing
         "n_workers": 1,  # workers for first-level parallelisation
         "gmsh_n_threads": 4,  # -1 means all the physical cores
         "elmer_n_processes": 4,  # processes for second-level parallelisation
@@ -89,6 +92,9 @@ elmer_export_parameters = {
         "1t1_gap&1t1_signal_3": [4.0, 8.0],
         "1t1_gap&1t1_ground": [4.0, 8.0],
     },
+    # "paraview_automation": {
+    #    "enable": False,
+    # }
 }
 
 # Get layout
@@ -119,8 +125,20 @@ simulations += cross_sweep_simulation(
     },
 )
 
+# Automation parameters for ParaView visualisation
+paraview_settings = {
+    "enable": True,
+    "threshold": [1, 1],
+    "threshold_scalars": ["CELLS", "GeometryIds"],
+}
+
+if paraview_settings["enable"] == True:
+    setup_paraview_macro(**paraview_settings)
+
+
 # Export simulation files
 export_elmer(simulations, **elmer_export_parameters)
 
 # Write and open OAS file
-open_with_klayout_or_default_application(export_simulation_oas(simulations, dir_path))
+# open_with_klayout_or_default_application(export_simulation_oas(simulations, dir_path))
+export_simulation_oas(simulations, dir_path)

--- a/klayout_package/python/scripts/simulations/post_process/paraview_macro.py
+++ b/klayout_package/python/scripts/simulations/post_process/paraview_macro.py
@@ -1,0 +1,79 @@
+# WHAT IS THIS FILE?
+# This file contains a .py "macro" that runs from within ParaView to automatically load and format of data files created during simulations.
+
+# WHY DOES THIS FILE TRIGGER "PYTHON ANALYSIS" WARNINGS WHEN OPENED IN VSCODE OR SIMILAR SOFTWARE?
+# This file uses dependencies that are NOT KQCircuits dependencies because it does NOT run within the KQCircuits environment.
+# The file is copied over to an output folder and ultimately runs from within a ParaView window.
+# ParaView has an in-built Python environment with its own packages.
+#
+# If you use VSCode, you can disable python analysis warnings by adding the following to your `.vscode/settings.json`:
+#   ```
+#   {
+#       ...
+#           "python.analysis.ignore": [ "**/paraview_macro.py", "**/paraview_state.py"]
+#       ...
+#   }
+#   ```
+
+
+# IMPORTS
+from paraview.simple import *
+
+paraview.simple._DisableFirstRenderCameraReset()
+
+# RE-WRITABLE VARIABLES
+# Since you cannot pass variables to a ParaView macro,
+# the variables below are written/re-written externally before running the Macro inside ParaView.
+data_folder = ""
+data_files = []
+kwargs = {"enable": True, "threshold": [1, 1], "threshold_scalars": ["CELLS", "GeometryIds"]}
+
+# LOAD DATA FILES
+registration_names = [f.rsplit("/")[1].split(".")[0] for f in data_files]
+for i in range(len(registration_names)):
+    reader = XMLPartitionedUnstructuredGridReader(
+        FileName=[data_folder + "/" + data_files[i]], registrationName=registration_names[i]
+    )
+    reader.TimeArray = "None"
+
+# INIT VIEW
+render_view = GetActiveViewOrCreate("RenderView")
+
+# FORMAT DATA
+for i in range(len(registration_names)):
+    parent = FindSource(registration_names[i])
+    parent.TimeArray = "None"
+    display = Show(parent, render_view, "UnstructuredGridRepresentation")
+    display.Representation = "Surface"
+    display.SetScalarBarVisibility(render_view, True)
+    Hide(parent, render_view)
+
+# ADD THRESHOLDS
+for i in range(len(registration_names)):
+    parent = FindSource(registration_names[i])
+    threshold = Threshold(registrationName=f"{registration_names[i]}-threshold", Input=parent)
+    threshold.ThresholdMethod = "Between"
+    threshold.LowerThreshold = kwargs["threshold"][0]
+    threshold.UpperThreshold = kwargs["threshold"][1]
+    threshold.Scalars = kwargs["threshold_scalars"]
+    threshold_display = Show(threshold, render_view, "UnstructuredGridRepresentation")
+    threshold_display.Representation = "Surface"
+    threshold_display.SetScalarBarVisibility(render_view, True)
+    if i + 1 < len(registration_names):
+        Hide(threshold, render_view)
+
+# UPDATE COLOURS
+potentialLUT = GetColorTransferFunction("potential")
+potentialPWF = GetOpacityTransferFunction("potential")
+potentialTF2D = GetTransferFunction2D("potential")
+
+# UPDATE LAYOUT & VIEW
+layout = GetLayout()
+layout.SetSize(720, 650)
+render_view.ResetCamera(False, 0.9)
+render_view.Update()
+render_view.Set(
+    CameraPosition=[0.001, 0.001, 0.006455783139039206],
+    CameraFocalPoint=[0.001, 0.001, 0.00022500000000000005],
+    CameraParallelScale=0.0016126453422870138,
+)

--- a/klayout_package/python/scripts/simulations/post_process/paraview_state.py
+++ b/klayout_package/python/scripts/simulations/post_process/paraview_state.py
@@ -1,0 +1,68 @@
+# WHAT IS THIS FILE?
+# This file contains a .py "blank-slate" state that can be loaded into ParaView to set a common departing point for subsequent macros. It is used as part of simulations when there is a need to automate rendering in ParaView.
+
+# WHY DOES THIS FILE TRIGGER "PYTHON ANALYSIS" WARNINGS WHEN OPENED IN VSCODE OR SIMILAR SOFTWARE?
+# This file uses dependencies that are NOT KQCircuits dependencies because it does NOT run within the KQCircuits environment.
+# The file is copied over to an output folder and ultimately runs from within a ParaView window.
+# ParaView has an in-built Python environment with its own packages.
+#
+# If you use VSCode, you can disable python analysis warnings by adding the following to your `.vscode/settings.json`:
+#   ```
+#   {
+#       ...
+#           "python.analysis.ignore": [ "**/paraview_macro.py", "**/paraview_state.py"]
+#       ...
+#   }
+#   ```
+
+
+# FOUNDATIONAL STATE FILE GENERATED USING PARAVIEW V. 6.0.0-RC1
+import paraview
+
+paraview.compatibility.major = 6
+paraview.compatibility.minor = 0
+
+# IMPORTS
+from paraview.simple import *
+
+paraview.simple._DisableFirstRenderCameraReset()
+
+# SETUP VIEWS
+# Get material library
+materialLibrary1 = GetMaterialLibrary()
+
+# Create a foundational render view
+renderView1 = CreateView("RenderView")
+renderView1.Set(
+    ViewSize=[720, 650],
+    CameraFocalDisk=1.0,
+    OSPRayMaterialLibrary=materialLibrary1,
+)
+
+# LAYOUTS
+# Empty active view
+SetActiveView(None)
+
+# Create layout
+layout1 = CreateLayout(name="Layout #1")
+layout1.AssignView(0, renderView1)
+layout1.SetSize(720, 650)
+
+# Restore active view
+SetActiveView(renderView1)
+
+# OTHER UNUSED BASIC CONFIGS
+# Get time animation track, time-keeper, animation scene
+timeAnimationCue1 = GetTimeTrack()
+timeKeeper1 = GetTimeKeeper()
+animationScene1 = GetAnimationScene()
+
+# Init animation scene
+animationScene1.Set(
+    ViewModules=renderView1,
+    Cues=timeAnimationCue1,
+    AnimationTime=0.0,
+)
+
+# Restore active source
+SetActiveSource(None)


### PR DESCRIPTION
The commits on this PR aim to (and will) enable automated visualisation of simulations using ParaView in a way that is easily applicable across simulations.

The key driving idea:
- You can't pass arguments to a macro running in ParaView, but you can slightly modify the macro before feeding it to ParaView so that it always reflects the specific needs of a given sweep (and this turned out the be surprisingly achievable). 

Accordingly, the flow of actions goes as follows:
- A template macro exists
- When the simulation runs, the macro is set up with parameters applicable for all sweeps.
- Macro (and an additional file used to set a clean "state") is copied over to the simulation outputs.
- The paths to data_files are updated on each sweep.
- On each sweep, paraview is called using a clean state and a macro specific to the sweep.

The first commit contains:
- General approach for simulations producing pvtu files.
- Test using the `concentrictransmon_couplings_sim.py` simulation, which already works end to end. 

Subsequent commits will:
- Implement the approach for simulations producing vtu files.
- Test the approach with other simulation files.