### PR TITLE
Remove t_cross_parameters helper

### DIFF
--- a/klayout_package/python/kqcircuits/chips/demo.py
+++ b/klayout_package/python/kqcircuits/chips/demo.py
@@ -29,7 +29,7 @@ from kqcircuits.elements.airbridge_connection import AirbridgeConnection
 from kqcircuits.elements.waveguide_composite import WaveguideComposite
 from kqcircuits.util.node import Node
 from kqcircuits.elements.waveguide_coplanar import WaveguideCoplanar
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.test_structures.junction_test_pads.junction_test_pads import JunctionTestPads
 from kqcircuits.util.geometry_helper import point_shift_along_vector
 
@@ -212,7 +212,11 @@ class Demo(Chip):
             label_trans=pya.DCplxTrans(0.2),
             align_to=cap_ref_abs["port_b"],
             align="port_bottom",
-            **t_cross_parameters(a=self.a, b=self.b, a2=self.a, b2=self.b, length_extra_side=30),
+            lengths=[self.a / 2 + self.b, self.a / 2 + self.b, self.a / 2 + self.b + 30],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
         )
 
     def produce_probelines(self):

--- a/klayout_package/python/kqcircuits/chips/demo_twoface.py
+++ b/klayout_package/python/kqcircuits/chips/demo_twoface.py
@@ -25,7 +25,7 @@ from kqcircuits.junctions.junction import Junction
 from kqcircuits.qubits.swissmon import Swissmon
 from kqcircuits.elements.waveguide_composite import WaveguideComposite
 from kqcircuits.util.node import Node
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.pya_resolver import pya
 from kqcircuits.util.geometry_helper import point_shift_along_vector
 from kqcircuits.util.parameters import Param, pdt, add_parameters_from
@@ -189,9 +189,12 @@ class DemoTwoface(Chip):
 
         tcross_cell = self.add_element(
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(
-                a=self.a, b=self.b, a2=self.a, b2=self.b, length_extra_side=30, face_ids=[self.face_ids[1]]
-            ),
+            lengths=[self.a / 2 + self.b, self.a / 2 + self.b, self.a / 2 + self.b + 30],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
+            face_ids=[self.face_ids[1]],
         )
         tcross_ref_rel = self.get_refpoints(tcross_cell, pya.DTrans(tcross_rot, False, 0, 0))
         tcross_trans = pya.DTrans(tcross_rot, False, cap_ref_abs["port_b"] - tcross_ref_rel["port_bottom"])

--- a/klayout_package/python/kqcircuits/chips/shaping.py
+++ b/klayout_package/python/kqcircuits/chips/shaping.py
@@ -25,7 +25,7 @@ from kqcircuits.elements.meander import Meander
 from kqcircuits.junctions.squid import Squid
 from kqcircuits.qubits.swissmon import Swissmon
 from kqcircuits.elements.waveguide_coplanar import WaveguideCoplanar
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.util.coupler_lib import cap_params
 
 
@@ -100,9 +100,15 @@ class Shaping(Chip):
         # Waveguide t-cross used in multiple locations
         cross1 = self.add_element(
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(
-                a=self.a, b=self.b, a2=self.a, b2=self.b, length_extra_side=2 * self.a, length_extra=50
-            ),
+            lengths=[
+                self.a / 2 + self.b + 50,
+                self.a / 2 + self.b + 50,
+                self.a / 2 + self.b + 2 * self.a,
+            ],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
         )
         cross1_refpoints_rel = self.get_refpoints(cross1, pya.DTrans(0, False, 0, 0))
         cross1_length = cross1_refpoints_rel["port_right"].distance(cross1_refpoints_rel["port_left"])

--- a/klayout_package/python/kqcircuits/chips/simple.py
+++ b/klayout_package/python/kqcircuits/chips/simple.py
@@ -22,7 +22,7 @@ from kqcircuits.chips.chip import Chip
 from kqcircuits.util.parameters import Param, pdt
 from kqcircuits.qubits.swissmon import Swissmon
 from kqcircuits.elements.waveguide_coplanar import WaveguideCoplanar
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.elements.finger_capacitor_square import FingerCapacitorSquare
 
 
@@ -51,7 +51,13 @@ class Simple(Chip):
         # WaveguideCoplanarSplitter
         _pos = pya.DTrans(launchers["SE"][0].x, launchers["WN"][0].y)
         _, tcross_refs = self.insert_cell(
-            WaveguideCoplanarSplitter, _pos, **t_cross_parameters(a=self.a, b=self.b, a2=self.a, b2=self.b)
+            WaveguideCoplanarSplitter,
+            _pos,
+            lengths=[self.a / 2 + self.b, self.a / 2 + self.b, self.a / 2 + self.b],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
         )
 
         # Waveguides: WN -> Swissmon -> FingerCapacitorSquare -> WaveguideCoplanarSplitter -> EN

--- a/klayout_package/python/kqcircuits/chips/single_xmons.py
+++ b/klayout_package/python/kqcircuits/chips/single_xmons.py
@@ -23,7 +23,7 @@ from kqcircuits.chips.chip import Chip
 from kqcircuits.elements.meander import Meander
 from kqcircuits.qubits.swissmon import Swissmon
 from kqcircuits.elements.waveguide_coplanar import WaveguideCoplanar
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.pya_resolver import pya
 from kqcircuits.util.coupler_lib import cap_params
 from kqcircuits.util.parameters import Param, pdt, add_parameters_from
@@ -333,7 +333,11 @@ class SingleXmons(Chip):
 
         cell_cross = self.add_element(
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=self.a, b=self.b, a2=self.a, b2=self.b, length_extra_side=2 * self.a),
+            lengths=[self.a / 2 + self.b, self.a / 2 + self.b, self.a / 2 + self.b + 2 * self.a],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
         )
         inst_crosses = []
 

--- a/klayout_package/python/kqcircuits/chips/xmons_direct_coupling.py
+++ b/klayout_package/python/kqcircuits/chips/xmons_direct_coupling.py
@@ -25,7 +25,7 @@ from kqcircuits.qubits.swissmon import Swissmon
 from kqcircuits.elements.waveguide_composite import WaveguideComposite
 from kqcircuits.util.node import Node
 from kqcircuits.elements.waveguide_coplanar_taper import WaveguideCoplanarTaper
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.pya_resolver import pya
 from kqcircuits.util.coupler_lib import cap_params
 from kqcircuits.util.parameters import Param, pdt, add_parameters_from
@@ -53,7 +53,11 @@ class XMonsDirectCoupling(Chip):
             pya.DTrans(pos_start.x, end_y),
             inst_name=(f"PL{name}" if name else None),
             label_trans=pya.DTrans.R90,
-            **t_cross_parameters(a=self.a, b=self.b, a2=self.a, b2=self.b, length_extra_side=20, length_extra=0),
+            lengths=[self.a / 2 + self.b, self.a / 2 + self.b, self.a / 2 + self.b + 20],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
         )
 
         # Finger cap
@@ -81,14 +85,11 @@ class XMonsDirectCoupling(Chip):
         # T to tail and straight
         rr_cross_cell = self.add_element(
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(
-                length_extra_side=40,
-                length_extra=0,
-                a=ro_a,
-                b=ro_b,
-                a2=ro_a,
-                b2=ro_b,
-            ),
+            lengths=[ro_a / 2 + ro_b, ro_a / 2 + ro_b, ro_a / 2 + ro_b + 40],
+            angles=[0, 180, 270],
+            a_list=[ro_a, ro_a, ro_a],
+            b_list=[ro_b, ro_b, ro_b],
+            port_names=["right", "left", "bottom"],
         )
         rr_cross_ref_rel = self.get_refpoints(rr_cross_cell, pya.DTrans.R90)
         _, rr_cross_ref = self.insert_cell(

--- a/klayout_package/python/kqcircuits/elements/quarter_wave_cpw_resonator.py
+++ b/klayout_package/python/kqcircuits/elements/quarter_wave_cpw_resonator.py
@@ -20,7 +20,7 @@ from kqcircuits.pya_resolver import pya
 from kqcircuits.util.parameters import Param, pdt
 from kqcircuits.elements.element import Element
 from kqcircuits.elements.waveguide_coplanar import WaveguideCoplanar
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.util.coupler_lib import cap_params
 from kqcircuits.util.refpoints import WaveguideToSimPort
 from kqcircuits.elements.waveguide_composite import WaveguideComposite
@@ -77,13 +77,11 @@ class QuarterWaveCpwResonator(Element):
 
         cell_cross = self.add_element(
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(
-                length_extra_side=2 * self.a,
-                a=self.a,
-                b=self.b,
-                a2=self.a,
-                b2=self.b,
-            ),
+            lengths=[self.a / 2 + self.b, self.a / 2 + self.b, self.a / 2 + self.b + 2 * self.a],
+            angles=[0, 180, 270],
+            a_list=[self.a, self.a, self.a],
+            b_list=[self.b, self.b, self.b],
+            port_names=["right", "left", "bottom"],
         )
 
         cell_ab_crossing = self.add_element(Airbridge)

--- a/klayout_package/python/kqcircuits/elements/waveguide_coplanar_splitter.py
+++ b/klayout_package/python/kqcircuits/elements/waveguide_coplanar_splitter.py
@@ -152,37 +152,3 @@ class WaveguideCoplanarSplitter(Element):
             points += arc_points(r, angle_rad + next_rad, angle_rad + pi / 2, self.n)
 
         return pya.DPolygon(points)
-
-
-def t_cross_parameters(
-    a=Element.get_schema()["a"].default,
-    b=Element.get_schema()["b"].default,
-    a2=Element.a,
-    b2=Element.b,
-    length_extra=0,
-    length_extra_side=0,
-    **kwargs,
-):
-    """A utility function to easily produce T-cross splitter (old WaveguideCoplanarTCross).
-
-    Args:
-        a: Width of center conductor
-        b: Width of gap
-        a2: Center conductor width of the side waveguide
-        b2: Gap of the side waveguide
-        length_extra: Extra length
-        length_extra_side: Extra length of the side waveguide
-
-    Returns:
-        dictionary of parameters for WaveguideCoplanarSplitter
-    """
-    length = a2 / 2 + b2 + length_extra
-    length2 = a / 2 + b + length_extra_side
-    return {
-        "lengths": [length, length, length2],
-        "angles": [0, 180, 270],
-        "a_list": [a, a, a2],
-        "b_list": [b, b, b2],
-        "port_names": ["right", "left", "bottom"],
-        **kwargs,
-    }

--- a/klayout_package/python/scripts/macros/generate/test_waveguide_composite.lym
+++ b/klayout_package/python/scripts/macros/generate/test_waveguide_composite.lym
@@ -45,7 +45,7 @@ from kqcircuits.elements.airbridge_connection import AirbridgeConnection
 from kqcircuits.elements.waveguide_coplanar_taper import WaveguideCoplanarTaper
 from kqcircuits.elements.finger_capacitor_square import FingerCapacitorSquare
 from kqcircuits.elements.finger_capacitor_taper import FingerCapacitorTaper
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.elements.flip_chip_connectors.flip_chip_connector_rf import FlipChipConnectorRf
 from kqcircuits.defaults import default_faces
 from kqcircuits.elements.hanger_resonator import HangerResonator
@@ -81,15 +81,28 @@ nodes = [
     Node(pya.DPoint(0, -800)),
     Node(pya.DPoint(50,-800), WaveguideCoplanarSplitter,
          align=("port_left", "port_right"),                # Specify input and output port to connect
-         length_extra_side=100, **t_cross_parameters(length_extra_side=100)),
+         lengths=[11, 11, 111],
+         angles=[0, 180, 270],
+         a_list=[10, 10, 10],
+         b_list=[6, 6, 6],
+         port_names=["right", "left", "bottom"]),
 #    Node(pya.DPoint(150, 0)),                             # A bend is inserted towards the next point automatically
     Node(pya.DPoint(250, -750)),                           # Specify one point before the next TCross to define it's direction
     Node(pya.DPoint(300, -750), WaveguideCoplanarSplitter,
          align=("port_right", "port_left"),                # Reverse port order to change orientation
          inst_name="second_tee",                           # Specify instance name to export element refpoints
-         length_extra_side=100, **t_cross_parameters(length_extra_side=100)),
+         lengths=[11, 11, 111],
+         angles=[0, 180, 270],
+         a_list=[10, 10, 10],
+         b_list=[6, 6, 6],
+         port_names=["right", "left", "bottom"]),
     Node(pya.DPoint(400, -750)),
-    Node(pya.DPoint(500, -750), WaveguideCoplanarSplitter, **t_cross_parameters(),
+    Node(pya.DPoint(500, -750), WaveguideCoplanarSplitter,
+         lengths=[11, 11, 11],
+         angles=[0, 180, 270],
+         a_list=[10, 10, 10],
+         b_list=[6, 6, 6],
+         port_names=["right", "left", "bottom"],
          r=50,                                             # "Element Nodes" may change curvature for the following section(s)
          align=("port_bottom", "port_right")),             # Ports can be at arbitrary angles if they have corner refpoints
     Node(pya.DPoint(600, -1000)),

--- a/tests/elements/waveguide_composite/test_create.py
+++ b/tests/elements/waveguide_composite/test_create.py
@@ -17,7 +17,7 @@
 # and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
 import pytest
 
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.pya_resolver import pya
 from kqcircuits.elements.waveguide_composite import WaveguideComposite
 from kqcircuits.util.node import Node
@@ -57,14 +57,22 @@ def nodes1():
         Node(
             pya.DPoint(2150, 0),
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=10, b=5),
+            lengths=[11, 11, 10],
+            angles=[0, 180, 270],
+            a_list=[10, 10, 10],
+            b_list=[5, 5, 6],
+            port_names=["right", "left", "bottom"],
             align=("port_left", "port_right"),
         ),
         Node(pya.DPoint(2350, 50)),
         Node(
             pya.DPoint(2400, 50),
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=10, b=5),
+            lengths=[11, 11, 10],
+            angles=[0, 180, 270],
+            a_list=[10, 10, 10],
+            b_list=[5, 5, 6],
+            port_names=["right", "left", "bottom"],
             align=("port_right", "port_left"),
             inst_name="second_tee",
         ),
@@ -72,7 +80,11 @@ def nodes1():
         Node(
             pya.DPoint(2600, 50),
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=10, b=5),
+            lengths=[11, 11, 10],
+            angles=[0, 180, 270],
+            a_list=[10, 10, 10],
+            b_list=[5, 5, 6],
+            port_names=["right", "left", "bottom"],
             align=("port_bottom", "port_right"),
         ),
         Node(pya.DPoint(2700, -200)),
@@ -101,14 +113,22 @@ def nodes2():
         Node(
             pya.DPoint(2150, 0),
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=10, b=5),
+            lengths=[11, 11, 10],
+            angles=[0, 180, 270],
+            a_list=[10, 10, 10],
+            b_list=[5, 5, 6],
+            port_names=["right", "left", "bottom"],
             align=("port_left", "port_right"),
         ),
         Node(pya.DPoint(2350, 50)),
         Node(
             pya.DPoint(2400, 50),
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=10, b=5),
+            lengths=[11, 11, 10],
+            angles=[0, 180, 270],
+            a_list=[10, 10, 10],
+            b_list=[5, 5, 6],
+            port_names=["right", "left", "bottom"],
             align=("port_right", "port_left"),
             inst_name="second_tee",
         ),
@@ -116,7 +136,11 @@ def nodes2():
         Node(
             pya.DPoint(2600, 50),
             WaveguideCoplanarSplitter,
-            **t_cross_parameters(a=10, b=5),
+            lengths=[11, 11, 10],
+            angles=[0, 180, 270],
+            a_list=[10, 10, 10],
+            b_list=[5, 5, 6],
+            port_names=["right", "left", "bottom"],
             align=("port_bottom", "port_right"),
         ),
         Node(pya.DPoint(2700, -200)),

--- a/tests/util/gui_helper/test_node_from_text.py
+++ b/tests/util/gui_helper/test_node_from_text.py
@@ -22,7 +22,7 @@ from kqcircuits.elements.airbridge_connection import AirbridgeConnection
 from kqcircuits.elements.airbridges.airbridge import Airbridge
 from kqcircuits.elements.finger_capacitor_square import FingerCapacitorSquare
 from kqcircuits.elements.flip_chip_connectors.flip_chip_connector_rf import FlipChipConnectorRf
-from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter, t_cross_parameters
+from kqcircuits.elements.waveguide_coplanar_splitter import WaveguideCoplanarSplitter
 from kqcircuits.elements.waveguide_coplanar_taper import WaveguideCoplanarTaper
 from kqcircuits.pya_resolver import pya
 from kqcircuits.util.node import Node


### PR DESCRIPTION
## Summary
- remove the `t_cross_parameters` helper from `WaveguideCoplanarSplitter`
- replace all in-scope usages with explicit `WaveguideCoplanarSplitter` parameters
- keep the previous T-cross lengths, angles, port names, and conductor/gap widths at each call site

Fixes #123.

## Validation
- `rg -n t_cross_parameters Y:\db\goal_5_income\worktrees\KQCircuits-t-cross-123` returned no matches
- import sweep for `WaveguideCoplanarSplitter`, `QuarterWaveCpwResonator`, and the updated chip classes: `imports-ok`
- focused headless pytest with a local Python 3.12 `pyreadline` compatibility shim: `27 passed in 0.38s`
- headless creation smoke test passed for `QuarterWaveCpwResonator`, `Demo`, `DemoTwoface`, `SingleXmons`, `Simple`, `Shaping`, and `XMonsDirectCoupling`
- `git diff --check` passed; it only printed Windows LF/CRLF warnings

AI disclosure: I used OpenAI Codex to help inspect the call sites, make the mechanical refactor, and run validation.