### PR TITLE
Improve Instance Hierarchy Browser marker highlighting

### DIFF
--- a/klayout_package/python/kqcircuits/util/instance_hierarchy_helpers.py
+++ b/klayout_package/python/kqcircuits/util/instance_hierarchy_helpers.py
@@ -19,7 +19,7 @@
 from typing import List
 from dataclasses import dataclass
 
-from kqcircuits.defaults import default_faces
+from kqcircuits.defaults import default_faces, default_face_id
 from kqcircuits.pya_resolver import pya
 
 
@@ -82,25 +82,26 @@ def _get_instance_primary_face_id(instance: pya.Instance) -> str:
                 return face_ids[0]
         except TypeError:
             pass
-    return "1t1"
+    return default_face_id
 
 
 def get_instance_marker_polygons(
-    layout: pya.Layout, instance: pya.Instance, trans: pya.DCplxTrans | None = None
+    instance: pya.Instance, trans: pya.DCplxTrans | None = None, marker_shape_layer: str = "ground_grid_avoidance"
 ) -> List[pya.DPolygon]:
     """Return ground-grid silhouette polygons for an instance in top-cell coordinates.
 
     Args:
-        layout: Layout containing the instance.
         instance: Instance whose geometry should be highlighted.
         trans: Optional instance transform in top-cell coordinates. Defaults to ``instance.dcplx_trans``.
+        marker_shape_layer: Name of the layer to use for marker shapes. Defaults to ``"ground_grid_avoidance"``.
 
-    Returns: DPolygons from the instance's primary face ``ground_grid_avoidance`` layer.
+    Returns: DPolygons from the instance's primary face marker layer.
     """
+    layout = instance.layout()
     instance_trans = instance.dcplx_trans if trans is None else trans
     face_id = _get_instance_primary_face_id(instance)
-    face = default_faces.get(face_id, default_faces["1t1"])
-    marker_layer = layout.layer(face["ground_grid_avoidance"])
+    face = default_faces[face_id]
+    marker_layer = layout.layer(face[marker_shape_layer])
 
     polygons = []
     for shape_iter in instance.cell.begin_shapes_rec(marker_layer):

--- a/klayout_package/python/kqcircuits/util/instance_hierarchy_helpers.py
+++ b/klayout_package/python/kqcircuits/util/instance_hierarchy_helpers.py
@@ -19,6 +19,7 @@
 from typing import List
 from dataclasses import dataclass
 
+from kqcircuits.defaults import default_faces
 from kqcircuits.pya_resolver import pya
 
 
@@ -68,6 +69,45 @@ def get_cell_instance_hierarchy(layout: pya.Layout, cell_index: int) -> List[Ins
                 )
             )
     return results
+
+
+def _get_instance_primary_face_id(instance: pya.Instance) -> str:
+    """Return the primary face id for an instance, or the default KQC face."""
+    face_ids = instance.pcell_parameter("face_ids")
+    if isinstance(face_ids, str):
+        return face_ids
+    if face_ids is not None:
+        try:
+            if len(face_ids) > 0:
+                return face_ids[0]
+        except TypeError:
+            pass
+    return "1t1"
+
+
+def get_instance_marker_polygons(
+    layout: pya.Layout, instance: pya.Instance, trans: pya.DCplxTrans | None = None
+) -> List[pya.DPolygon]:
+    """Return ground-grid silhouette polygons for an instance in top-cell coordinates.
+
+    Args:
+        layout: Layout containing the instance.
+        instance: Instance whose geometry should be highlighted.
+        trans: Optional instance transform in top-cell coordinates. Defaults to ``instance.dcplx_trans``.
+
+    Returns: DPolygons from the instance's primary face ``ground_grid_avoidance`` layer.
+    """
+    instance_trans = instance.dcplx_trans if trans is None else trans
+    face_id = _get_instance_primary_face_id(instance)
+    face = default_faces.get(face_id, default_faces["1t1"])
+    marker_layer = layout.layer(face["ground_grid_avoidance"])
+
+    polygons = []
+    for shape_iter in instance.cell.begin_shapes_rec(marker_layer):
+        polygon = shape_iter.shape().dpolygon
+        if polygon is not None:
+            polygons.append(instance_trans * shape_iter.dtrans() * polygon)
+    return polygons
 
 
 def formatted_cell_instance_hierarchy(inst_data: InstanceHierarchy) -> str:

--- a/klayout_package/python/scripts/macros/measure/instance_hierarchy_browser.lym
+++ b/klayout_package/python/scripts/macros/measure/instance_hierarchy_browser.lym
@@ -49,14 +49,32 @@ and rerun the macro if needed.
 
 from kqcircuits.pya_resolver import pya
 from kqcircuits.klayout_view import KLayoutView
+from kqcircuits.util.instance_hierarchy_helpers import get_instance_marker_polygons
 
 view = KLayoutView(current=True)
 layout = view.layout
 top_cell = view.active_cell
 
+selection_markers = []
+
+def clear_marker_highlights():
+    """Clear visual markers created by this instance hierarchy browser."""
+    while selection_markers:
+        marker = selection_markers.pop()
+        if not marker.destroyed():
+            marker.destroy()
+
+
 def create_dialog():
     """Simple dialog containing a TreeWidget"""
-    dialog = pya.QDialog(pya.Application.instance().main_window())
+    class InstanceHierarchyDialog(pya.QDialog):
+        """Dialog that clears instance marker highlights when closed."""
+
+        def closeEvent(self, *args):
+            clear_marker_highlights()
+            super().closeEvent(*args)
+
+    dialog = InstanceHierarchyDialog(pya.Application.instance().main_window())
     dialog.windowTitle = "Instance Hierarchy"
     dialog.setModal(False)
 
@@ -78,13 +96,20 @@ dialog.show()
 top_item = pya.QTreeWidgetItem([top_cell.name, ""])
 tree_widget.insertTopLevelItem(0, top_item)
 
-def add_instances(item, cell):
+def add_instances(item, cell, inst_path=None, trans=None):
     """Recursively add child instances of a cell as subitems of a given tree widget item.
 
     Args:
          item: parent QTreeWidgetItem
          cell: parent Cell in the layout
+         inst_path: instance path from top cell to ``cell``
+         trans: transformation from top cell to ``cell``
     """
+    if inst_path is None:
+        inst_path = []
+    if trans is None:
+        trans = pya.DCplxTrans()
+
     child_insts = list(cell.each_inst())
     child_insts_by_cell = {inst.cell_index: [] for inst in child_insts}
     for inst in child_insts:
@@ -99,47 +124,63 @@ def add_instances(item, cell):
             for inst, inst_name in cell_insts:
                 child_item = pya.QTreeWidgetItem([inst.cell.name, "" if inst_name is None else inst_name])
                 child_item._inst = inst
+                child_item._inst_path = inst_path + [inst]
+                child_item._inst_trans = trans * inst.dcplx_trans
                 item.insertChild(None, child_item)
-                add_instances(child_item, inst.cell)
+                add_instances(child_item, inst.cell, child_item._inst_path, child_item._inst_trans)
 
 # Populate dialog
 add_instances(top_item, top_cell)
 top_item.setExpanded(True)
 
+def add_marker_highlights(inst, trans):
+    """Add marker highlights for the selected instance geometry."""
+    for polygon in get_instance_marker_polygons(layout, inst, trans):
+        marker = pya.Marker()
+        marker.set_polygon(polygon)
+        marker.color = 0xDD2222
+        marker.dither_pattern = -1
+        marker.vertex_size = 0
+        marker.line_width = 3
+        marker.halo = 1
+        view.layout_view.add_marker(marker)
+        selection_markers.append(marker)
+
+
+def select_instance_item(item):
+    """Select and highlight the instance represented by a tree widget item."""
+    inst = getattr(item, "_inst", None)
+    if inst is None:
+        return False
+
+    inst_path = pya.ObjectInstPath()
+    inst_path.cv_index = view.cell_view.index()
+    inst_path.top = view.cell_view.cell_index
+    inst_path.path = [pya.InstElement(path_inst) for path_inst in getattr(item, "_inst_path", [inst])]
+    view.layout_view.select_object(inst_path)
+    add_marker_highlights(inst, getattr(item, "_inst_trans", inst.dcplx_trans))
+    return True
+
+
 def selection_changed(*args):
     """Callback when an instance is selected in the dialog. Selects the corresponding instance in the layout.
     """
+    clear_marker_highlights()
     view.layout_view.clear_object_selection()
     for item in tree_widget.selectedItems():
-        inst = getattr(item, "_inst", None)
-        if inst is not None:
-            # Select the instance
-            inst_path = pya.ObjectInstPath()
-            inst_path.cv_index = view.cell_view.index()
-            inst_path.top = view.cell_view.cell_index
-            # path should be a list from top to the final instance, but just giving the final instance seems to work too
-            inst_path.path = [pya.InstElement(inst)]
-            view.layout_view.select_object(inst_path)
+        select_instance_item(item)
 
 
 def double_clicked(*args):
     """Callback on double click. Selects the instance in the layout and opens the instance property dialog."""
+    clear_marker_highlights()
     view.layout_view.clear_object_selection()
     for item in tree_widget.selectedItems():
-        inst = getattr(item, "_inst", None)
-        if inst is not None:
-            # Select the instance
-            inst_path = pya.ObjectInstPath()
-            inst_path.cv_index = view.cell_view.index()
-            inst_path.top = view.cell_view.cell_index
-            # path should be a list from top to the final instance, but just giving the final instance seems to work too
-            inst_path.path = [pya.InstElement(inst)]
-            view.layout_view.select_object(inst_path)
-        
+        if select_instance_item(item):
             # Open property dialog.
             menu = pya.MainWindow.instance().menu()
             menu.action('edit_menu.show_properties').trigger()
-        break  # Only accept one selection
+            break  # Only accept one selection
    
 
 tree_widget.itemSelectionChanged = selection_changed

--- a/klayout_package/python/scripts/macros/measure/instance_hierarchy_browser.lym
+++ b/klayout_package/python/scripts/macros/measure/instance_hierarchy_browser.lym
@@ -51,6 +51,13 @@ from kqcircuits.pya_resolver import pya
 from kqcircuits.klayout_view import KLayoutView
 from kqcircuits.util.instance_hierarchy_helpers import get_instance_marker_polygons
 
+# Marker highlight parameters (adjust these to change marker appearance)
+M_COLOR = 0xDD2222
+M_DITHER = -1
+M_VTX_SIZE = 0
+M_LINE_WIDTH = 3
+M_HALO = 1
+
 view = KLayoutView(current=True)
 layout = view.layout
 top_cell = view.active_cell
@@ -135,14 +142,14 @@ top_item.setExpanded(True)
 
 def add_marker_highlights(inst, trans):
     """Add marker highlights for the selected instance geometry."""
-    for polygon in get_instance_marker_polygons(layout, inst, trans):
+    for polygon in get_instance_marker_polygons(inst, trans):
         marker = pya.Marker()
         marker.set_polygon(polygon)
-        marker.color = 0xDD2222
-        marker.dither_pattern = -1
-        marker.vertex_size = 0
-        marker.line_width = 3
-        marker.halo = 1
+        marker.color = M_COLOR
+        marker.dither_pattern = M_DITHER
+        marker.vertex_size = M_VTX_SIZE
+        marker.line_width = M_LINE_WIDTH
+        marker.halo = M_HALO
         view.layout_view.add_marker(marker)
         selection_markers.append(marker)
 

--- a/tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py
+++ b/tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py
@@ -1,0 +1,49 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import pytest
+
+from kqcircuits.defaults import default_faces
+from kqcircuits.pya_resolver import pya
+from kqcircuits.util import instance_hierarchy_helpers
+
+
+def test_get_instance_marker_polygons_applies_recursive_and_instance_transforms():
+    """Marker polygons are returned in top-cell coordinates for recursively nested shapes."""
+    assert hasattr(instance_hierarchy_helpers, "get_instance_marker_polygons")
+
+    layout = pya.Layout()
+    top_cell = layout.create_cell("top_cell")
+    selected_cell = layout.create_cell("selected_cell")
+    nested_cell = layout.create_cell("nested_cell")
+    marker_layer = layout.layer(default_faces["1t1"]["ground_grid_avoidance"])
+
+    nested_cell.shapes(marker_layer).insert(pya.DBox(0, 0, 10, 20))
+    selected_cell.insert(pya.DCellInstArray(nested_cell.cell_index(), pya.DCplxTrans(1, 90, False, 5, 0)))
+    selected_inst = top_cell.insert(
+        pya.DCellInstArray(selected_cell.cell_index(), pya.DCplxTrans(1, 0, False, 100, 200))
+    )
+
+    polygons = instance_hierarchy_helpers.get_instance_marker_polygons(layout, selected_inst)
+
+    assert len(polygons) == 1
+    marker_box = polygons[0].bbox()
+    assert marker_box.left == pytest.approx(85)
+    assert marker_box.right == pytest.approx(105)
+    assert marker_box.bottom == pytest.approx(200)
+    assert marker_box.top == pytest.approx(210)

--- a/tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py
+++ b/tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py
@@ -20,13 +20,11 @@ import pytest
 
 from kqcircuits.defaults import default_faces
 from kqcircuits.pya_resolver import pya
-from kqcircuits.util import instance_hierarchy_helpers
+from kqcircuits.util.instance_hierarchy_helpers import get_instance_marker_polygons
 
 
 def test_get_instance_marker_polygons_applies_recursive_and_instance_transforms():
     """Marker polygons are returned in top-cell coordinates for recursively nested shapes."""
-    assert hasattr(instance_hierarchy_helpers, "get_instance_marker_polygons")
-
     layout = pya.Layout()
     top_cell = layout.create_cell("top_cell")
     selected_cell = layout.create_cell("selected_cell")
@@ -39,7 +37,7 @@ def test_get_instance_marker_polygons_applies_recursive_and_instance_transforms(
         pya.DCellInstArray(selected_cell.cell_index(), pya.DCplxTrans(1, 0, False, 100, 200))
     )
 
-    polygons = instance_hierarchy_helpers.get_instance_marker_polygons(layout, selected_inst)
+    polygons = get_instance_marker_polygons(selected_inst)
 
     assert len(polygons) == 1
     marker_box = polygons[0].bbox()


### PR DESCRIPTION
## Summary
- Draw marker polygons for the selected Instance Hierarchy Browser item so nested element geometry is highlighted in the layout view.
- Add a helper for collecting transformed marker polygons from an instance hierarchy path.
- Add focused coverage for nested instance marker polygon extraction.

Closes #124.
Related: https://unitaryhack.dev/bounties/

## Problem
Selecting an item in the Instance Hierarchy Browser selected the object path, but the visible layout highlighting did not clearly mark the selected element geometry, especially for nested instances.

## Fix
- Add `get_instance_marker_polygons` for transformed polygon extraction from hierarchy entries.
- Update `instance_hierarchy_browser.lym` to create and clear KLayout markers for the selected hierarchy item.
- Cover nested marker extraction with a focused test.

## Validation
- `./.venv/bin/python -m pytest -q tests/util/instance_hierarchy_helpers/test_get_cell_instance_hierarchy.py` -> 8 passed.
- `./.venv/bin/python -m pytest -q tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py` -> 1 passed.
- `./.venv/bin/python -m pytest -q tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py tests/util/instance_hierarchy_helpers/test_get_cell_instance_hierarchy.py` -> 9 passed.
- `./.venv/bin/python -m pytest -q tests/util/instance_hierarchy_helpers` -> 23 passed.
- `./.venv/bin/python -m black --check -l 120 klayout_package/python/kqcircuits/util/instance_hierarchy_helpers.py tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py` -> passed.
- `./.venv/bin/python -m pylint klayout_package/python/kqcircuits/util/instance_hierarchy_helpers.py tests/util/instance_hierarchy_helpers/test_get_instance_marker_polygons.py` -> 10.00/10.
- `git diff --check && git diff --cached --check` -> clean.
- XML parse plus extracted Python compile for `instance_hierarchy_browser.lym` -> OK.
- Standalone KLayout marker/object-selection smoke -> OK.
- Munch Qubits geometry smoke found marker polygons for nested `Waveguide Composite` and object-path marker setup succeeded.

## Risk notes
- I validated the marker and geometry behavior with KLayout Python/standalone APIs, not a full interactive desktop KLayout run, because the `klayout` application executable is not installed in this environment.
- I understand the IQM individual CLA may be required before acceptance.

AI assistance was used to inspect the issue surface and run the submitted validation.
