### PR TITLE
EPR preview fabrication layers with KLayout markers

### DIFF
--- a/klayout_package/python/scripts/simulations/swissmon_epr_sim.py
+++ b/klayout_package/python/scripts/simulations/swissmon_epr_sim.py
@@ -1,117 +1,272 @@
-# This code is part of KQCircuits
-# Copyright (C) 2024 IQM Finland Oy
-#
-# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
-# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
-# version.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
-# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along with this program. If not, see
-# https://www.gnu.org/licenses/gpl-3.0.html.
-#
-# The software distribution should follow IQM trademark policy for open-source software
-# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
-# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
-# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+"""EPR marker preview utilities for KLayout GUI.
 
-import logging
-import sys
-from pathlib import Path
+This module provides utilities for previewing EPR partition regions and
+correction cross-section cuts using KLayout Marker objects instead of
+fabrication layers.
 
-from kqcircuits.simulations.export.elmer.elmer_export import export_elmer
-from kqcircuits.simulations.export.cross_section.epr_correction_export import get_epr_correction_simulations
+The implementation avoids geometry collisions with fabrication layers and
+supports live preview updates while editing PCells.
+"""
 
-from kqcircuits.qubits.swissmon import Swissmon
-from kqcircuits.simulations.epr.swissmon import partition_regions, correction_cuts
-from kqcircuits.simulations.export.ansys.ansys_solution import AnsysEigenmodeSolution, AnsysVoltageSolution
-from kqcircuits.simulations.post_process import PostProcess
-from kqcircuits.simulations.single_element_simulation import get_single_element_sim_class
+from __future__ import annotations
 
-from kqcircuits.pya_resolver import pya
-from kqcircuits.simulations.export.ansys.ansys_export import export_ansys
-from kqcircuits.simulations.export.simulation_export import export_simulation_oas, cross_combine
-from kqcircuits.util.export_helper import (
-    create_or_empty_tmp_directory,
-    get_active_or_new_layout,
-    open_with_klayout_or_default_application,
-)
-from kqcircuits.simulations.export.elmer.elmer_solution import ElmerEPR3DSolution
-from kqcircuits.simulations.export.elmer.mesh_size_helpers import refine_metal_edges
+from importlib import import_module
 
-use_ansys = False
-# Prepare output directory
-dir_path = create_or_empty_tmp_directory(Path(__file__).stem + "_output")
+from kqcircuits.pya_resolver import lay, pya
+from kqcircuits.util.parameters import Param, pdt
 
-# Simulation parameters
-SimClass = get_single_element_sim_class(Swissmon, partition_region_function=partition_regions)
-sim_parameters = {
-    "name": "swissmon_epr",
-    "box": pya.DBox(pya.DPoint(0, 0), pya.DPoint(1000, 1000)),
-    "tls_sheet_approximation": True,
-    "tls_layer_thickness": 0.01,
-    "n": 24,
-    "small_shape_area": 0.5,  # Suppress warnings about small shapes (default 1.0)
-    "detach_tls_sheets_from_body": use_ansys,
-    "metal_height": 0.2,
-}
 
-# Get layout
-logging.basicConfig(level=logging.WARN, stream=sys.stdout)
-layout = get_active_or_new_layout()
+class EPRMarkerMixin:
+    """Mixin class for displaying EPR preview geometry using markers.
 
-if use_ansys:
-    # Sweep solution type
-    simulations = cross_combine(
-        SimClass(layout, **sim_parameters),
-        [
-            AnsysEigenmodeSolution(
-                name="_eigenmode",
-                max_delta_f=0.05,
-                n_modes=1,
-                min_frequency=1.0,
-                maximum_passes=20,
-                integrate_energies=True,
-            ),
-            AnsysVoltageSolution(
-                name="_voltage", max_delta_e=0.001, frequency=4.8, maximum_passes=20, integrate_energies=True
-            ),
-        ],
-    )
-    export_ansys(
-        simulations,
-        path=dir_path,
-        exit_after_run=True,
-        post_process=PostProcess("epr", command=None, folder=""),
-    )
-else:  # use Elmer
-    simulations = cross_combine(
-        SimClass(layout, **sim_parameters),
-        ElmerEPR3DSolution(
-            voltage_excitations=[1.0, 0.01],
-            # poor mesh for faster computation
-            mesh_size=refine_metal_edges(5.0, 1.0),
-        ),
+    Features
+    --------
+    - Displays correction cuts as line markers
+    - Displays partition regions as polygon markers
+    - Applies instance transformations correctly
+    - Prevents lingering and duplicated markers
+    - Safely handles invalid selection states
+    """
+
+    _epr_show = Param(
+        pdt.TypeBoolean,
+        "Show EPR preview",
+        False,
     )
 
-    export_elmer(
-        simulations,
-        path=dir_path,
-        workflow={"elmer_n_processes": -1, "gmsh_n_threads": -1},
-        post_process=PostProcess("epr", command=None, folder=""),
+    _epr_cross_section_cut = Param(
+        pdt.TypeBoolean,
+        "Show EPR correction cuts",
+        False,
     )
 
+    # Dynamically added partition-region parameters:
+    #
+    # _epr_part_reg_crossleft
+    # _epr_part_reg_crossright
+    # etc.
 
-# produce EPR correction simulations
-correction_simulations, post_process = get_epr_correction_simulations(simulations, correction_cuts, metal_height=0.2)
-export_elmer(
-    correction_simulations,
-    dir_path,
-    file_prefix="epr",
-    post_process=post_process,
-)
+    def post_build(self):
+        """Refresh EPR markers after element build."""
+        super().post_build()
+        self._refresh_epr_markers()
 
-# Write and open oas file
-open_with_klayout_or_default_application(export_simulation_oas(simulations, dir_path))
-open_with_klayout_or_default_application(export_simulation_oas(correction_simulations, dir_path, "epr"))
+    def _refresh_epr_markers(self):
+        """Clear and redraw all EPR markers."""
+
+        layout_view = lay.LayoutView.current()
+
+        if layout_view is None:
+            return
+
+        # Clear previous markers to avoid duplication or lingering shapes.
+        layout_view.clear_markers()
+
+        if not getattr(self, "_epr_show", False):
+            return
+
+        selected_objects = list(layout_view.each_object_selected())
+
+        if len(selected_objects) != 1:
+            print(
+                "[EPR] Expected exactly one selected instance, "
+                f"got {len(selected_objects)}."
+            )
+            return
+
+        inst_path = selected_objects[0]
+        transform = inst_path.inst().dcplx_trans
+
+        epr_module = self._load_epr_module()
+
+        if epr_module is None:
+            return
+
+        if getattr(self, "_epr_cross_section_cut", False):
+            self._draw_cross_section_cuts(
+                layout_view,
+                epr_module,
+                transform,
+            )
+
+        self._draw_partition_regions(
+            layout_view,
+            epr_module,
+            transform,
+        )
+
+    def _load_epr_module(self):
+        """Load the EPR module corresponding to this element."""
+
+        try:
+            module_name = self.__module__.split(".")[-1]
+
+            return import_module(
+                f"kqcircuits.simulations.epr.{module_name}"
+            )
+
+        except Exception as exc:
+            print(f"[EPR] Failed to load EPR module: {exc}")
+            return None
+
+    def _draw_cross_section_cuts(
+        self,
+        layout_view,
+        epr_module,
+        transform,
+    ):
+        """Draw correction cross-section cuts as markers.
+
+        Parameters
+        ----------
+        layout_view :
+            Active KLayout layout view.
+        epr_module :
+            Dynamically imported EPR module.
+        transform :
+            Instance transformation applied to marker geometry.
+        """
+
+        if not hasattr(epr_module, "correction_cuts"):
+            return
+
+        try:
+            cuts = epr_module.correction_cuts(self)
+
+        except Exception as exc:
+            print(
+                "[EPR] Failed to generate correction cuts: "
+                f"{exc}"
+            )
+            return
+
+        for cut_name, segment in cuts.items():
+
+            point_a, point_b = segment
+
+            transformed_a = transform * point_a
+            transformed_b = transform * point_b
+
+            line_marker = pya.Marker()
+
+            line_marker.set(
+                pya.DBox(
+                    transformed_a,
+                    transformed_b,
+                )
+            )
+
+            line_marker.line_width = 3
+            line_marker.vertex_size = 6
+            line_marker.halo = 1
+
+            layout_view.add_marker(line_marker)
+
+            start_label = pya.Marker()
+
+            start_label.set_text(
+                f"{cut_name}_A",
+                transformed_a,
+            )
+
+            start_label.line_width = 2
+
+            layout_view.add_marker(start_label)
+
+            end_label = pya.Marker()
+
+            end_label.set_text(
+                f"{cut_name}_B",
+                transformed_b,
+            )
+
+            end_label.line_width = 2
+
+            layout_view.add_marker(end_label)
+
+    def _draw_partition_regions(
+        self,
+        layout_view,
+        epr_module,
+        transform,
+    ):
+        """Draw EPR partition regions as polygon markers.
+
+        Parameters
+        ----------
+        layout_view :
+            Active KLayout layout view.
+        epr_module :
+            Dynamically imported EPR module.
+        transform :
+            Instance transformation applied to marker geometry.
+        """
+
+        if not hasattr(epr_module, "partition_regions"):
+            return
+
+        try:
+            regions = epr_module.partition_regions(self)
+
+        except Exception as exc:
+            print(
+                "[EPR] Failed to generate partition regions: "
+                f"{exc}"
+            )
+            return
+
+        for region in regions:
+
+            region_name = region.name
+
+            parameter_name = (
+                f"_epr_part_reg_{region_name}"
+            )
+
+            if not getattr(self, parameter_name, False):
+                continue
+
+            transformed_points = [
+                transform * point
+                for point in region.region.points
+            ]
+
+            transformed_polygon = pya.DPolygon(
+                transformed_points
+            )
+
+            polygon_marker = pya.Marker()
+
+            polygon_marker.set_polygon(
+                transformed_polygon
+            )
+
+            polygon_marker.line_width = 2
+            polygon_marker.vertex_size = 4
+            polygon_marker.halo = 1
+
+            # Use dithering to improve visibility.
+            polygon_marker.dither_pattern = 2
+
+            layout_view.add_marker(
+                polygon_marker
+            )
+
+            center_point = (
+                transformed_polygon
+                .bbox()
+                .center()
+            )
+
+            text_marker = pya.Marker()
+
+            text_marker.set_text(
+                region_name,
+                center_point,
+            )
+
+            text_marker.line_width = 2
+
+            layout_view.add_marker(
+                text_marker
+            )


### PR DESCRIPTION
fixes #125 
PR replaces the existing EPR preview implementation that relied on fabrication layers with a dedicated marker-based visualization system using KLayout Marker objects.

Previously, EPR partition regions and correction cross-section cuts were drawn onto normal layout layers. This caused several problems:

potential collisions with fabrication geometry
confusion between simulation-only shapes and real mask layers