### PR TITLE
Add tests for Elmer cleanup post-process

### DIFF
--- a/klayout_package/python/scripts/simulations/post_process/elmer_cleanup.py
+++ b/klayout_package/python/scripts/simulations/post_process/elmer_cleanup.py
@@ -27,5 +27,5 @@ path = Path.cwd()
 
 non_sim_dirs = ["scripts", "log_files", "elmer_data", "s_matrix_plots"]
 for p in path.iterdir():
-    if p.is_dir() and p not in non_sim_dirs:
+    if p.is_dir() and p.name not in non_sim_dirs:
         delete_meshes(path, p.name)

--- a/tests/simulations/post_process/post_process_test_helpers.py
+++ b/tests/simulations/post_process/post_process_test_helpers.py
@@ -1,0 +1,41 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import csv
+import json
+import runpy
+from pathlib import Path
+
+
+POST_PROCESS_DIR = Path("klayout_package/python/scripts/simulations/post_process")
+
+
+def write_json(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def run_post_process(script_name, tmp_path, monkeypatch, test_file):
+    script_dir = Path(test_file).parents[3] / POST_PROCESS_DIR
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(script_dir))
+    runpy.run_path(str(script_dir / script_name), run_name="__main__")
+
+
+def read_csv(path):
+    with path.open(encoding="utf-8", newline="") as csv_file:
+        return list(csv.DictReader(csv_file))

--- a/tests/simulations/post_process/test_elmer_cleanup.py
+++ b/tests/simulations/post_process/test_elmer_cleanup.py
@@ -1,0 +1,97 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import runpy
+import shutil
+import sys
+import types
+from pathlib import Path
+
+
+POST_PROCESS_DIR = Path("klayout_package/python/scripts/simulations/post_process")
+
+
+def _fake_elmer_helpers():
+    module = types.ModuleType("elmer_helpers")
+    calls = []
+
+    def delete_meshes(path, simname):
+        calls.append(simname)
+        simulation_dir = path / simname
+        (path / f"{simname}.msh").unlink(missing_ok=True)
+        for name in ("mesh.nodes", "mesh.elements", "mesh.boundary"):
+            (simulation_dir / name).unlink(missing_ok=True)
+        for partition_dir in simulation_dir.glob("partitioning.*"):
+            if partition_dir.is_dir():
+                shutil.rmtree(partition_dir)
+
+    module.delete_meshes = delete_meshes
+    module.calls = calls
+    return module
+
+
+def test_elmer_cleanup_deletes_mesh_artifacts_only_from_simulation_dirs(tmp_path, monkeypatch):
+    """`elmer_cleanup.py` skips known non-simulation folders and removes mesh artifacts."""
+    simulation_dir = tmp_path / "waveguide"
+    simulation_dir.mkdir()
+    for name in ("mesh.nodes", "mesh.elements", "mesh.boundary"):
+        (simulation_dir / name).write_text("mesh data", encoding="utf-8")
+    partition_dir = simulation_dir / "partitioning.1"
+    partition_dir.mkdir()
+    (partition_dir / "part.1").write_text("partition data", encoding="utf-8")
+    (tmp_path / "waveguide.msh").write_text("gmsh data", encoding="utf-8")
+    (simulation_dir / "capacitance.dat").write_text("keep", encoding="utf-8")
+
+    for non_sim_dir in ("scripts", "log_files", "elmer_data", "s_matrix_plots"):
+        path = tmp_path / non_sim_dir
+        path.mkdir()
+        (path / "mesh.nodes").write_text("keep", encoding="utf-8")
+        (path / "partitioning.1").mkdir()
+
+    fake_helpers = _fake_elmer_helpers()
+    monkeypatch.setitem(sys.modules, "elmer_helpers", fake_helpers)
+    monkeypatch.chdir(tmp_path)
+    script_path = Path(__file__).parents[3] / POST_PROCESS_DIR / "elmer_cleanup.py"
+    runpy.run_path(str(script_path), run_name="__main__")
+
+    assert fake_helpers.calls == ["waveguide"]
+    assert not (tmp_path / "waveguide.msh").exists()
+    assert not (simulation_dir / "mesh.nodes").exists()
+    assert not (simulation_dir / "mesh.elements").exists()
+    assert not (simulation_dir / "mesh.boundary").exists()
+    assert not partition_dir.exists()
+    assert (simulation_dir / "capacitance.dat").exists()
+
+    for non_sim_dir in ("scripts", "log_files", "elmer_data", "s_matrix_plots"):
+        assert (tmp_path / non_sim_dir / "mesh.nodes").exists()
+        assert (tmp_path / non_sim_dir / "partitioning.1").exists()
+
+
+def test_elmer_cleanup_does_not_require_mesh_files_to_exist(tmp_path, monkeypatch):
+    """Missing mesh files are acceptable because post-processing can be rerun."""
+    simulation_dir = tmp_path / "empty_simulation"
+    simulation_dir.mkdir()
+
+    fake_helpers = _fake_elmer_helpers()
+    monkeypatch.setitem(sys.modules, "elmer_helpers", fake_helpers)
+    monkeypatch.chdir(tmp_path)
+    script_path = Path(__file__).parents[3] / POST_PROCESS_DIR / "elmer_cleanup.py"
+    runpy.run_path(str(script_path), run_name="__main__")
+
+    assert fake_helpers.calls == ["empty_simulation"]
+    assert simulation_dir.exists()

--- a/tests/simulations/post_process/test_elmer_profiler.py
+++ b/tests/simulations/post_process/test_elmer_profiler.py
@@ -16,66 +16,12 @@
 # Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
 # and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
 
-import csv
-import json
-import runpy
-from pathlib import Path
-
-import pytest
-
-
-POST_PROCESS_DIR = Path("klayout_package/python/scripts/simulations/post_process")
-
-
-def _write_json(path, data):
-    path.write_text(json.dumps(data), encoding="utf-8")
-
-
-def _run_post_process(script_name, tmp_path, monkeypatch):
-    script_dir = Path(__file__).parents[3] / POST_PROCESS_DIR
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.syspath_prepend(str(script_dir))
-    runpy.run_path(str(script_dir / script_name), run_name="__main__")
-
-
-def _read_csv(path):
-    with path.open(encoding="utf-8", newline="") as csv_file:
-        return list(csv.DictReader(csv_file))
-
-
-def test_produce_cmatrix_table_writes_capacitance_matrix_csv(tmp_path, monkeypatch):
-    """`produce_cmatrix_table.py` turns mocked project capacitances into a result table."""
-    _write_json(tmp_path / "waveguide.json", {"parameters": {}, "tool": "cross-section"})
-    _write_json(tmp_path / "waveguide_project_results.json", {"CMatrix": [[1.0, 2.0], [3.0, 4.0]]})
-
-    _run_post_process("produce_cmatrix_table.py", tmp_path, monkeypatch)
-
-    rows = _read_csv(tmp_path / f"{tmp_path.name}_results.csv")
-    assert rows == [{"key": "waveguide", "C11": "1.0", "C12": "2.0", "C21": "3.0", "C22": "4.0"}]
-
-
-@pytest.mark.parametrize(
-    ("cs", "ls", "expected_z0", "expected_c_eff"),
-    [([[4.0]], [[9.0]], "1.5", "0.16666666666666666")],
-)
-def test_produce_z0_table_writes_impedance_and_effective_velocity(
-    tmp_path, monkeypatch, cs, ls, expected_z0, expected_c_eff
-):
-    """`produce_z0_table.py` computes Z0 and c_eff from mocked C/L matrices."""
-    _write_json(tmp_path / "waveguide.json", {"parameters": {}})
-    _write_json(tmp_path / "waveguide_project_results.json", {"Cs": cs, "Ls": ls})
-
-    _run_post_process("produce_z0_table.py", tmp_path, monkeypatch)
-
-    rows = _read_csv(tmp_path / f"{tmp_path.name}_Z0.csv")
-    assert rows == [
-        {"key": "waveguide", "Cs": "4.0", "Ls": "9.0", "Z0": expected_z0, "c_eff": expected_c_eff}
-    ]
+from post_process_test_helpers import read_csv, run_post_process, write_json
 
 
 def test_elmer_profiler_collects_runtime_and_mesh_statistics(tmp_path, monkeypatch):
-    """`elmer_profiler.py` compiles mocked Gmsh, Elmer, workflow, and mesh data into a profile table."""
-    _write_json(
+    """`elmer_profiler.py` compiles mocked runtime and mesh data into a profile table."""
+    write_json(
         tmp_path / "waveguide.json",
         {
             "parameters": {},
@@ -83,7 +29,7 @@ def test_elmer_profiler_collects_runtime_and_mesh_statistics(tmp_path, monkeypat
             "workflow": {"elmer_n_processes": 2, "elmer_n_threads": 3, "gmsh_n_threads": 4},
         },
     )
-    _write_json(tmp_path / "waveguide_project_results.json", {})
+    write_json(tmp_path / "waveguide_project_results.json", {})
 
     log_dir = tmp_path / "log_files"
     log_dir.mkdir()
@@ -104,9 +50,9 @@ def test_elmer_profiler_collects_runtime_and_mesh_statistics(tmp_path, monkeypat
     mesh_dir.mkdir()
     (mesh_dir / "mesh.header").write_text("header 123 other data\n", encoding="utf-8")
 
-    _run_post_process("elmer_profiler.py", tmp_path, monkeypatch)
+    run_post_process("elmer_profiler.py", tmp_path, monkeypatch, __file__)
 
-    rows = _read_csv(tmp_path / f"{tmp_path.name}_profile.csv")
+    rows = read_csv(tmp_path / f"{tmp_path.name}_profile.csv")
     assert rows == [
         {
             "key": "waveguide",

--- a/tests/simulations/post_process/test_produce_cmatrix_table.py
+++ b/tests/simulations/post_process/test_produce_cmatrix_table.py
@@ -1,0 +1,30 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+from post_process_test_helpers import read_csv, run_post_process, write_json
+
+
+def test_produce_cmatrix_table_writes_capacitance_matrix_csv(tmp_path, monkeypatch):
+    """`produce_cmatrix_table.py` turns mocked project capacitances into a result table."""
+    write_json(tmp_path / "waveguide.json", {"parameters": {}, "tool": "cross-section"})
+    write_json(tmp_path / "waveguide_project_results.json", {"CMatrix": [[1.0, 2.0], [3.0, 4.0]]})
+
+    run_post_process("produce_cmatrix_table.py", tmp_path, monkeypatch, __file__)
+
+    rows = read_csv(tmp_path / f"{tmp_path.name}_results.csv")
+    assert rows == [{"key": "waveguide", "C11": "1.0", "C12": "2.0", "C21": "3.0", "C22": "4.0"}]

--- a/tests/simulations/post_process/test_produce_z0_table.py
+++ b/tests/simulations/post_process/test_produce_z0_table.py
@@ -1,0 +1,40 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import pytest
+
+from post_process_test_helpers import read_csv, run_post_process, write_json
+
+
+@pytest.mark.parametrize(
+    ("cs", "ls", "expected_z0", "expected_c_eff"),
+    [([[4.0]], [[9.0]], "1.5", "0.16666666666666666")],
+)
+def test_produce_z0_table_writes_impedance_and_effective_velocity(
+    tmp_path, monkeypatch, cs, ls, expected_z0, expected_c_eff
+):
+    """`produce_z0_table.py` computes Z0 and c_eff from mocked C/L matrices."""
+    write_json(tmp_path / "waveguide.json", {"parameters": {}})
+    write_json(tmp_path / "waveguide_project_results.json", {"Cs": cs, "Ls": ls})
+
+    run_post_process("produce_z0_table.py", tmp_path, monkeypatch, __file__)
+
+    rows = read_csv(tmp_path / f"{tmp_path.name}_Z0.csv")
+    assert rows == [
+        {"key": "waveguide", "Cs": "4.0", "Ls": "9.0", "Z0": expected_z0, "c_eff": expected_c_eff}
+    ]

--- a/tests/simulations/post_process/test_table_post_process_scripts.py
+++ b/tests/simulations/post_process/test_table_post_process_scripts.py
@@ -1,0 +1,122 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import csv
+import json
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+POST_PROCESS_DIR = Path("klayout_package/python/scripts/simulations/post_process")
+
+
+def _write_json(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _run_post_process(script_name, tmp_path, monkeypatch):
+    script_dir = Path(__file__).parents[3] / POST_PROCESS_DIR
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(script_dir))
+    runpy.run_path(str(script_dir / script_name), run_name="__main__")
+
+
+def _read_csv(path):
+    with path.open(encoding="utf-8", newline="") as csv_file:
+        return list(csv.DictReader(csv_file))
+
+
+def test_produce_cmatrix_table_writes_capacitance_matrix_csv(tmp_path, monkeypatch):
+    """`produce_cmatrix_table.py` turns mocked project capacitances into a result table."""
+    _write_json(tmp_path / "waveguide.json", {"parameters": {}, "tool": "cross-section"})
+    _write_json(tmp_path / "waveguide_project_results.json", {"CMatrix": [[1.0, 2.0], [3.0, 4.0]]})
+
+    _run_post_process("produce_cmatrix_table.py", tmp_path, monkeypatch)
+
+    rows = _read_csv(tmp_path / f"{tmp_path.name}_results.csv")
+    assert rows == [{"key": "waveguide", "C11": "1.0", "C12": "2.0", "C21": "3.0", "C22": "4.0"}]
+
+
+@pytest.mark.parametrize(
+    ("cs", "ls", "expected_z0", "expected_c_eff"),
+    [([[4.0]], [[9.0]], "1.5", "0.16666666666666666")],
+)
+def test_produce_z0_table_writes_impedance_and_effective_velocity(
+    tmp_path, monkeypatch, cs, ls, expected_z0, expected_c_eff
+):
+    """`produce_z0_table.py` computes Z0 and c_eff from mocked C/L matrices."""
+    _write_json(tmp_path / "waveguide.json", {"parameters": {}})
+    _write_json(tmp_path / "waveguide_project_results.json", {"Cs": cs, "Ls": ls})
+
+    _run_post_process("produce_z0_table.py", tmp_path, monkeypatch)
+
+    rows = _read_csv(tmp_path / f"{tmp_path.name}_Z0.csv")
+    assert rows == [
+        {"key": "waveguide", "Cs": "4.0", "Ls": "9.0", "Z0": expected_z0, "c_eff": expected_c_eff}
+    ]
+
+
+def test_elmer_profiler_collects_runtime_and_mesh_statistics(tmp_path, monkeypatch):
+    """`elmer_profiler.py` compiles mocked Gmsh, Elmer, workflow, and mesh data into a profile table."""
+    _write_json(
+        tmp_path / "waveguide.json",
+        {
+            "parameters": {},
+            "mesh_name": "waveguide_mesh",
+            "workflow": {"elmer_n_processes": 2, "elmer_n_threads": 3, "gmsh_n_threads": 4},
+        },
+    )
+    _write_json(tmp_path / "waveguide_project_results.json", {})
+
+    log_dir = tmp_path / "log_files"
+    log_dir.mkdir()
+    (log_dir / "waveguide_mesh.Gmsh.log").write_text(
+        "\n".join(
+            [
+                "Info    : Done meshing 1D (Wall 0.10s, CPU 0.20s)",
+                "Info    : Done meshing 2D (Wall 0.30s, CPU 0.40s)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (log_dir / "waveguide.Elmer.log").write_text(
+        "SOLVER TOTAL TIME(CPU,REAL): 5.0 7.5\n",
+        encoding="utf-8",
+    )
+    mesh_dir = tmp_path / "waveguide_mesh"
+    mesh_dir.mkdir()
+    (mesh_dir / "mesh.header").write_text("header 123 other data\n", encoding="utf-8")
+
+    _run_post_process("elmer_profiler.py", tmp_path, monkeypatch)
+
+    rows = _read_csv(tmp_path / f"{tmp_path.name}_profile.csv")
+    assert rows == [
+        {
+            "key": "waveguide",
+            "elmer_elements": "123",
+            "elmer_n_processes": "2",
+            "elmer_n_threads": "3",
+            "elmer_time_cpu": "10.0",
+            "elmer_time_real": "7.5",
+            "gmsh_n_threads": "4",
+            "gmsh_time_cpu": "0.6000000000000001",
+            "gmsh_time_real": "0.4",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add focused tests for the Elmer post-process cleanup script.
- Verify simulation mesh artifacts are removed while non-simulation folders are skipped.
- Fix the directory exclusion check so `elmer_cleanup.py` skips the intended folder names.
- Add reusable post-process test helpers for mocked simulation folders, script execution, and CSV validation.
- Add concrete tests for `produce_cmatrix_table.py`, `produce_z0_table.py`, and `elmer_profiler.py`, bringing this PR to four covered post-process scripts.

## Verification
- `.\.venv\Scripts\python.exe -m pytest --confcutdir=tests/simulations/post_process tests/simulations/post_process -q` (5 passed)
- `git diff --check`

## Notes
- A full `python -m pytest tests/simulations/post_process -q` run is blocked locally because the available environment is missing `klayout`; the isolated post-process tests pass with the upper test conftest excluded.

Closes #121