### PR TITLE
Add post-process script test infrastructure

### DIFF
--- a/tests/simulations/post_process/conftest.py
+++ b/tests/simulations/post_process/conftest.py
@@ -1,0 +1,78 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import csv
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POST_PROCESS_DIR = REPO_ROOT / "klayout_package" / "python" / "scripts" / "simulations" / "post_process"
+
+
+class PostProcessSandbox:
+    """Temporary simulation-folder harness for post-process scripts."""
+
+    def __init__(self, path):
+        self.path = Path(path)
+
+    def write_json(self, file_name, data):
+        file_path = self.path / file_name
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return file_path
+
+    def write_text(self, file_name, data):
+        file_path = self.path / file_name
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(data, encoding="utf-8")
+        return file_path
+
+    def run_script(self, script_name, *args):
+        env = os.environ.copy()
+        python_path = [str(POST_PROCESS_DIR)]
+        if env.get("PYTHONPATH"):
+            python_path.append(env["PYTHONPATH"])
+        env["PYTHONPATH"] = os.pathsep.join(python_path)
+
+        result = subprocess.run(
+            [sys.executable, str(POST_PROCESS_DIR / script_name), *[str(arg) for arg in args]],
+            cwd=self.path,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        return result
+
+    def csv_rows(self, suffix):
+        matches = list(self.path.glob(f"*{suffix}"))
+        assert len(matches) == 1
+        with matches[0].open(encoding="utf-8", newline="") as csv_file:
+            return list(csv.DictReader(csv_file))
+
+
+@pytest.fixture
+def post_process_sandbox(tmp_path):
+    return PostProcessSandbox(tmp_path)

--- a/tests/simulations/post_process/test_post_process_scripts.py
+++ b/tests/simulations/post_process/test_post_process_scripts.py
@@ -1,0 +1,112 @@
+# This code is part of KQCircuits
+# Copyright (C) 2026 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import pytest
+
+
+def test_produce_cmatrix_table_writes_capacitance_matrix(post_process_sandbox):
+    post_process_sandbox.write_json(
+        "sample.json",
+        {
+            "parameters": {"width": 10},
+            "ports": [],
+            "tool": "capacitance",
+        },
+    )
+    post_process_sandbox.write_json("sample_project_results.json", {"Cs": [[1.0, 0.2], [0.2, 1.5]]})
+
+    post_process_sandbox.run_script("produce_cmatrix_table.py")
+
+    rows = post_process_sandbox.csv_rows("_results.csv")
+    assert rows == [
+        {
+            "key": "sample",
+            "C11": "1.0",
+            "C12": "0.2",
+            "C21": "0.2",
+            "C22": "1.5",
+        }
+    ]
+
+
+def test_produce_z0_table_writes_waveguide_parameters(post_process_sandbox):
+    post_process_sandbox.write_json("line.json", {"parameters": {"width": 10}})
+    post_process_sandbox.write_json("line_project_results.json", {"Cs": [[4.0]], "Ls": [[9.0]]})
+
+    post_process_sandbox.run_script("produce_z0_table.py")
+
+    row = post_process_sandbox.csv_rows("_Z0.csv")[0]
+    assert row["key"] == "line"
+    assert float(row["Cs"]) == 4.0
+    assert float(row["Ls"]) == 9.0
+    assert float(row["Z0"]) == 1.5
+    assert float(row["c_eff"]) == pytest.approx(1 / 6)
+
+
+def test_elmer_profiler_writes_runtime_and_mesh_statistics(post_process_sandbox):
+    post_process_sandbox.write_json(
+        "profiled.json",
+        {
+            "parameters": {"width": 10},
+            "mesh_name": "profiled_mesh",
+            "workflow": {
+                "elmer_n_processes": 2,
+                "elmer_n_threads": 3,
+                "gmsh_n_threads": 4,
+            },
+        },
+    )
+    post_process_sandbox.write_json("profiled_project_results.json", {})
+    post_process_sandbox.write_text(
+        "log_files/profiled.Elmer.log",
+        "noise\nSOLVER TOTAL TIME(CPU,REAL): 5.00 7.50\n",
+    )
+    post_process_sandbox.write_text(
+        "log_files/profiled_mesh.Gmsh.log",
+        "Info    : Done meshing 1D (Wall 0.25s, CPU 0.50s)\n"
+        "Info    : Done meshing 2D (Wall 1.25s, CPU 1.50s)\n",
+    )
+    post_process_sandbox.write_text("profiled_mesh/mesh.header", "4 123 0\n")
+
+    post_process_sandbox.run_script("elmer_profiler.py")
+
+    row = post_process_sandbox.csv_rows("_profile.csv")[0]
+    assert row["key"] == "profiled"
+    assert row["elmer_n_processes"] == "2"
+    assert row["elmer_n_threads"] == "3"
+    assert row["gmsh_n_threads"] == "4"
+    assert row["elmer_elements"] == "123"
+    assert float(row["elmer_time_cpu"]) == 10.0
+    assert float(row["elmer_time_real"]) == 7.5
+    assert float(row["gmsh_time_cpu"]) == 2.0
+    assert float(row["gmsh_time_real"]) == 1.5
+
+
+def test_produce_q_factor_table_writes_q_values_from_existing_epr(post_process_sandbox):
+    post_process_sandbox.write_json("sample.json", {"parameters": {"width": 10}})
+    post_process_sandbox.write_json("sample_project_results.json", {})
+    loss_tangents = post_process_sandbox.write_json("loss_tangents.json", {"ma": 0.001, "ms": 0.002})
+    post_process_sandbox.write_text("sample_epr.csv", "key,E_total,p_ma,p_ms\nsample,1.0,0.25,0.5\n")
+
+    post_process_sandbox.run_script("produce_q_factor_table.py", loss_tangents)
+
+    row = post_process_sandbox.csv_rows("_q_factors.csv")[0]
+    assert row["key"] == "sample"
+    assert float(row["Q_ma"]) == 4000.0
+    assert float(row["Q_ms"]) == 1000.0
+    assert float(row["Q_total"]) == 800.0


### PR DESCRIPTION
Closes #121.

## Summary
- add a reusable pytest sandbox for running post-process scripts against temporary mocked simulation folders
- cover four post-process scripts with concrete output checks:
  - produce_cmatrix_table.py
  - produce_z0_table.py
  - elmer_profiler.py
  - produce_q_factor_table.py

## Validation
- python -m pytest tests/simulations/post_process -q --confcutdir=tests/simulations/post_process -> 4 passed
- git diff --cached --check -> passed

The --confcutdir flag was used only for local validation because this Windows checkout does not have KLayout installed; it keeps the run focused on the new subprocess-based post-process tests. CI should exercise the tests in the normal installed project environment.

## AI assistance disclosure
OpenAI Codex was used to help prepare this contribution.