### PR TITLE
Add Elmer export macro for layouts drawn in the KLayout GUI

### DIFF
--- a/klayout_package/python/kqcircuits/simulations/export/elmer/gui_layout_export.py
+++ b/klayout_package/python/kqcircuits/simulations/export/elmer/gui_layout_export.py
@@ -1,0 +1,252 @@
+# This code is part of KQCircuits
+# Copyright (C) 2025 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+"""Export a manually drawn KLayout layout as an Elmer simulation.
+
+These helpers back the ``export_elmer.lym`` macro. They walk the element hierarchy of a top cell, place
+simulation ports at launchers and qubit junctions, work out the simulation box from the launcher positions,
+and hand the result to :func:`export_elmer`. The logic lives here, separate from the macro, so it can be
+exercised without the KLayout GUI.
+
+Elements are identified both from live PCell data (the usual case when a design is open in the GUI) and, as a
+fallback, from the cell name when the layout has been flattened or loaded from a file without PCell context.
+"""
+
+from pathlib import Path
+
+from kqcircuits.pya_resolver import pya
+from kqcircuits.defaults import default_layers
+from kqcircuits.elements.element import get_refpoints
+from kqcircuits.elements.launcher import Launcher
+from kqcircuits.qubits.qubit import Qubit
+from kqcircuits.simulations.port import EdgePort, InternalPort
+from kqcircuits.simulations.simulation import Simulation
+from kqcircuits.simulations.export.elmer.elmer_solution import ElmerVectorHelmholtzSolution
+from kqcircuits.simulations.export.elmer.elmer_export import export_elmer
+from kqcircuits.simulations.export.elmer.mesh_size_helpers import refine_metal_edges
+
+
+def default_workflow():
+    """Return the default Elmer workflow used by the GUI export."""
+    return {
+        "run_gmsh_gui": True,
+        "run_elmergrid": True,
+        "run_elmer": True,
+        "run_paraview": True,
+        "python_executable": "python",
+        "gmsh_n_threads": -1,
+        "elmer_n_processes": -1,
+        "elmer_n_threads": 1,
+    }
+
+
+def default_mesh_size():
+    """Return the default mesh size dictionary, refined at the metal edges."""
+    return {"global_max": 200.0, **refine_metal_edges(10, 1.0)}
+
+
+def _class_name(cell):
+    """Return the KQC element class name the cell was generated from.
+
+    Cell names look like ``Launcher``, ``Swissmon$1`` or ``Double*Pads``, where ``$`` marks a variant and
+    ``*`` stands for a space. This strips those so the result matches the element class display name.
+    """
+    return cell.name.split("$")[0].replace("*", " ").strip()
+
+
+def _has_sim_junction(cell, layout):
+    """Return True if the cell directly contains a Sim junction instance."""
+    return any(_class_name(layout.cell(inst.cell_index)) == "Sim" for inst in cell.each_inst())
+
+
+def _is_launcher(inst, cell):
+    """Return True if the instance is a Launcher, from PCell data or the cell name."""
+    pcell = inst.pcell_declaration()
+    if pcell is not None:
+        return isinstance(pcell, Launcher)
+    return _class_name(cell) == "Launcher"
+
+
+def _is_qubit(inst, cell, layout):
+    """Return True if the instance is a qubit, from PCell data or a Sim junction child."""
+    pcell = inst.pcell_declaration()
+    if pcell is not None:
+        return isinstance(pcell, Qubit)
+    return _has_sim_junction(cell, layout)
+
+
+def _outward_direction(trans):
+    """Return the global direction of the launcher local +x axis.
+
+    The launcher pad and the chip edge sit on the local +x side, so this vector points outward from the
+    design. It is taken from transformed points rather than the rotation code so it stays correct under
+    mirroring.
+    """
+    return (trans * pya.DPoint(1, 0)) - (trans * pya.DPoint(0, 0))
+
+
+def _launcher_signal_location(inst, cell, trans):
+    """Return the EdgePort location at the launcher pad edge, in global coordinates.
+
+    With PCell data the pad edge is at local ``(s + l, 0)``, the point opposite the launcher opening. For a
+    flat cell the same edge is taken from the local bounding box along +x.
+    """
+    params = inst.pcell_parameters_by_name()
+    if "s" in params and "l" in params:
+        reach = params["s"] + params["l"]
+    else:
+        reach = cell.dbbox().right
+    return trans * pya.DPoint(reach, 0)
+
+
+def _squid_ports(cell, trans, refpoint_layer):
+    """Return the global (signal, ground) points of a qubit Sim junction, or None if absent."""
+    refpoints = get_refpoints(refpoint_layer, cell, pya.DTrans(), None).dict()
+    for name in refpoints:
+        if name.endswith("port_squid_a"):
+            ground = name[:-1] + "b"
+            if ground in refpoints:
+                return trans * refpoints[name], trans * refpoints[ground]
+    return None
+
+
+def collect_ports(top_cell):
+    """Walk ``top_cell`` and build the simulation ports from launchers and qubits.
+
+    Returns a tuple ``(ports, edge_directions)``. ``ports`` is the list of :class:`Port`. ``edge_directions``
+    maps each EdgePort number to its outward :class:`pya.DVector`, used to place that port on the box edge.
+    Launchers and qubits are treated as leaves, every other instance is descended into so elements nested in
+    sub designs are still found.
+    """
+    layout = top_cell.layout()
+    refpoint_layer = layout.layer(default_layers["refpoints"])
+    ports = []
+    edge_directions = {}
+    counter = [1]
+
+    def visit(cell, trans):
+        # Snapshot the instances first. Setting junction_type below regenerates a qubit cell, which would
+        # invalidate a live instance iterator.
+        for inst in list(cell.each_inst()):
+            child = layout.cell(inst.cell_index)
+            child_trans = trans * inst.dcplx_trans
+            if _is_launcher(inst, child):
+                ports.append(EdgePort(counter[0], _launcher_signal_location(inst, child, child_trans)))
+                edge_directions[counter[0]] = _outward_direction(child_trans)
+                counter[0] += 1
+            elif _is_qubit(inst, child, layout):
+                if inst.pcell_declaration() is not None:
+                    inst["junction_type"] = "Sim"
+                    child = layout.cell(inst.cell_index)
+                squid = _squid_ports(child, child_trans, refpoint_layer)
+                if squid is not None:
+                    ports.append(InternalPort(counter[0], squid[0], squid[1]))
+                    counter[0] += 1
+            else:
+                visit(child, child_trans)
+
+    visit(top_cell, pya.DCplxTrans())
+    return ports, edge_directions
+
+
+def simulation_box(top_cell, ports, edge_directions, margin=100.0):
+    """Return the simulation box as a :class:`pya.DBox` and place the edge ports on its rim.
+
+    The box starts from the cell bounding box grown by ``margin``. Each side that faces a launcher is moved
+    to the outermost EdgePort on that side, then every EdgePort on that side is projected exactly onto the
+    edge. Manual placement is rarely pixel perfect, so this projection is what guarantees each EdgePort sits
+    on the box rim, which the Elmer export requires. A clear error is raised when the launcher orientations
+    leave no room for a valid box, for example a port facing right that ends up left of the opposite side.
+
+    The ``signal_location`` of the affected EdgePorts is updated in place.
+    """
+    geometry = top_cell.dbbox()
+    left, bottom = geometry.left - margin, geometry.bottom - margin
+    right, top = geometry.right + margin, geometry.top + margin
+
+    sides = {"left": [], "right": [], "bottom": [], "top": []}
+    for port in ports:
+        direction = edge_directions.get(port.number)
+        if direction is None:
+            continue
+        if abs(direction.x) >= abs(direction.y):
+            sides["right" if direction.x > 0 else "left"].append(port)
+        else:
+            sides["top" if direction.y > 0 else "bottom"].append(port)
+
+    if sides["left"]:
+        left = min(port.signal_location.x for port in sides["left"])
+    if sides["right"]:
+        right = max(port.signal_location.x for port in sides["right"])
+    if sides["bottom"]:
+        bottom = min(port.signal_location.y for port in sides["bottom"])
+    if sides["top"]:
+        top = max(port.signal_location.y for port in sides["top"])
+
+    if right - left <= 0 or top - bottom <= 0:
+        raise ValueError(
+            "Could not define a simulation box from the launcher positions. Check that the launchers point "
+            "outward and sit at the edge of the design."
+        )
+
+    for port in sides["left"]:
+        port.signal_location = pya.DPoint(left, port.signal_location.y)
+    for port in sides["right"]:
+        port.signal_location = pya.DPoint(right, port.signal_location.y)
+    for port in sides["bottom"]:
+        port.signal_location = pya.DPoint(port.signal_location.x, bottom)
+    for port in sides["top"]:
+        port.signal_location = pya.DPoint(port.signal_location.x, top)
+
+    return pya.DBox(left, bottom, right, top)
+
+
+def export_open_layout_to_elmer(
+    top_cell, path, *, name="gui_simulation", target_frequency=5.0, mesh_size=None, workflow=None, margin=100.0
+):
+    """Export the geometry in ``top_cell`` as an Elmer wave equation simulation.
+
+    Args:
+        top_cell: the top cell whose geometry is exported. The cell is modified, so the macro passes a copy.
+        path: directory the simulation files are written to.
+        name: simulation name, also the file name stem.
+        target_frequency: solver frequency in GHz.
+        mesh_size: Gmsh mesh size dictionary, defaults to :func:`default_mesh_size`.
+        workflow: Elmer workflow dictionary, defaults to :func:`default_workflow`.
+        margin: distance in micrometers added around the geometry on sides without a launcher.
+
+    Returns:
+        Path to the written simulation directory.
+    """
+    ports, edge_directions = collect_ports(top_cell)
+    if not edge_directions:
+        raise ValueError("No launchers found in the layout, cannot place edge ports for the simulation.")
+
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    box = simulation_box(top_cell, ports, edge_directions, margin)
+    simulation = Simulation.from_cell(top_cell, name=name, box=box, ports=ports)
+    solution = ElmerVectorHelmholtzSolution(
+        mesh_size=default_mesh_size() if mesh_size is None else mesh_size,
+        frequency=target_frequency,
+        # Use first order basis since the model is very large
+        quadratic_approximation=False,
+        linear_system_method="zmumps",
+        use_multigrid_solver=False,
+    )
+    return export_elmer([(simulation, solution)], path, workflow=default_workflow() if workflow is None else workflow)

--- a/klayout_package/python/kqcircuits/simulations/export/elmer/gui_layout_export.py
+++ b/klayout_package/python/kqcircuits/simulations/export/elmer/gui_layout_export.py
@@ -189,6 +189,11 @@ def collect_ports(top_cell):
     return ports, edge_directions, edge_footprints
 
 
+def _clamp(value, low, high):
+    """Clamp ``value`` to the closed interval ``[low, high]``."""
+    return min(max(value, low), high)
+
+
 def simulation_box(top_cell, ports, edge_directions, edge_footprints, margin=100.0):
     """Return the simulation box as a :class:`pya.DBox` and place the edge ports on its rim.
 
@@ -200,8 +205,9 @@ def simulation_box(top_cell, ports, edge_directions, edge_footprints, margin=100
     guarantees each EdgePort sits on the box rim, which the Elmer export requires.
 
     A clear error is raised when the launcher positions do not admit a valid box: when a side has no room
-    against the opposite side, or when the rim cannot pass through a launcher because it sits too far out
-    relative to its neighbour on the same side.
+    against the opposite side, when the rim cannot pass through a launcher because it sits too far out
+    relative to its neighbour on the same side or when the horizontal and vertical launchers do not agree
+    on one box, so a launcher falls past a box corner and has no point on the finite rim.
 
     The ``signal_location`` of the affected EdgePorts is updated in place.
     """
@@ -236,36 +242,56 @@ def simulation_box(top_cell, ports, edge_directions, edge_footprints, margin=100
             "outward and sit at the edge of the design."
         )
 
-    # Each launcher must still be crossed by its box edge, otherwise it has no point on the rim to host the
-    # port. This rejects a launcher that sits too far out compared to its neighbours on the same side.
+    # Each launcher must sit on its box edge. Two things can go wrong. The box edge may miss the launcher
+    # along its own axis, when the launcher sits too far out compared to its neighbours on the same side.
+    # Or the launcher may fall past a box corner along the other axis, when the horizontal and vertical
+    # launchers do not agree on one box, for example a south launcher pushed out beyond the right edge. Then
+    # there is no point on the finite rim to host the port, so both cases are rejected.
     edges = {"left": left, "right": right, "bottom": bottom, "top": top}
+    too_far_out = (
+        "A launcher sits too far outside the box for the box edge to reach it. The launcher locations are "
+        "incorrect: launchers on the same side should sit at a similar distance from the design."
+    )
+    inconsistent_box = (
+        "The launchers do not fit a single simulation box: a launcher falls past a box corner, so no box "
+        "holds every launcher. Check that the horizontal and vertical launchers all sit at the design edges."
+    )
+
+    # Left and right launchers: the edge must cross the launcher in x. The launcher must also overlap the
+    # vertical span so its port lands on the finite rim, not past a corner.
     for side in ("left", "right"):
         for port in sides[side]:
             footprint = edge_footprints.get(port.number)
-            if footprint is not None and not footprint.left - 1e-6 <= edges[side] <= footprint.right + 1e-6:
-                raise ValueError(
-                    "A launcher sits too far outside the box for the box edge to reach it. The launcher "
-                    "locations are incorrect: launchers on the same side should sit at a similar distance "
-                    "from the design."
-                )
+            if footprint is None:
+                continue
+            if not footprint.left - 1e-6 <= edges[side] <= footprint.right + 1e-6:
+                raise ValueError(too_far_out)
+            if footprint.bottom > top + 1e-6 or footprint.top < bottom - 1e-6:
+                raise ValueError(inconsistent_box)
+
+    # Bottom and top launchers, mirrored: the edge must cross the launcher in y. The launcher must overlap
+    # the horizontal span.
     for side in ("bottom", "top"):
         for port in sides[side]:
             footprint = edge_footprints.get(port.number)
-            if footprint is not None and not footprint.bottom - 1e-6 <= edges[side] <= footprint.top + 1e-6:
-                raise ValueError(
-                    "A launcher sits too far outside the box for the box edge to reach it. The launcher "
-                    "locations are incorrect: launchers on the same side should sit at a similar distance "
-                    "from the design."
-                )
+            if footprint is None:
+                continue
+            if not footprint.bottom - 1e-6 <= edges[side] <= footprint.top + 1e-6:
+                raise ValueError(too_far_out)
+            if footprint.left > right + 1e-6 or footprint.right < left - 1e-6:
+                raise ValueError(inconsistent_box)
 
+    # Project every EdgePort onto its box edge. The free coordinate is clamped into the rim so a launcher
+    # placed slightly past a corner still lands on the box, the same way the edge projection absorbs a small
+    # offset along the launcher's own axis.
     for port in sides["left"]:
-        port.signal_location = pya.DPoint(left, port.signal_location.y)
+        port.signal_location = pya.DPoint(left, _clamp(port.signal_location.y, bottom, top))
     for port in sides["right"]:
-        port.signal_location = pya.DPoint(right, port.signal_location.y)
+        port.signal_location = pya.DPoint(right, _clamp(port.signal_location.y, bottom, top))
     for port in sides["bottom"]:
-        port.signal_location = pya.DPoint(port.signal_location.x, bottom)
+        port.signal_location = pya.DPoint(_clamp(port.signal_location.x, left, right), bottom)
     for port in sides["top"]:
-        port.signal_location = pya.DPoint(port.signal_location.x, top)
+        port.signal_location = pya.DPoint(_clamp(port.signal_location.x, left, right), top)
 
     return pya.DBox(left, bottom, right, top)
 

--- a/klayout_package/python/kqcircuits/simulations/export/elmer/gui_layout_export.py
+++ b/klayout_package/python/kqcircuits/simulations/export/elmer/gui_layout_export.py
@@ -1,5 +1,5 @@
 # This code is part of KQCircuits
-# Copyright (C) 2025 IQM Finland Oy
+# Copyright (C) 2026 IQM Finland Oy
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
@@ -58,6 +58,26 @@ def default_workflow():
 def default_mesh_size():
     """Return the default mesh size dictionary, refined at the metal edges."""
     return {"global_max": 200.0, **refine_metal_edges(10, 1.0)}
+
+
+def default_wave_equation_solution(target_frequency=5.0, mesh_size=None):
+    """Return the default Elmer wave equation solution used by the GUI export.
+
+    A first order basis is used because the GUI models are large. ``mesh_size`` defaults to
+    :func:`default_mesh_size`.
+
+    Args:
+        target_frequency: solver frequency in GHz.
+        mesh_size: Gmsh mesh size dictionary, defaults to :func:`default_mesh_size`.
+    """
+    return ElmerVectorHelmholtzSolution(
+        mesh_size=default_mesh_size() if mesh_size is None else mesh_size,
+        frequency=target_frequency,
+        # Use first order basis since the model is very large
+        quadratic_approximation=False,
+        linear_system_method="zmumps",
+        use_multigrid_solver=False,
+    )
 
 
 def _class_name(cell):
@@ -128,50 +148,60 @@ def _squid_ports(cell, trans, refpoint_layer):
 def collect_ports(top_cell):
     """Walk ``top_cell`` and build the simulation ports from launchers and qubits.
 
-    Returns a tuple ``(ports, edge_directions)``. ``ports`` is the list of :class:`Port`. ``edge_directions``
-    maps each EdgePort number to its outward :class:`pya.DVector`, used to place that port on the box edge.
-    Launchers and qubits are treated as leaves, every other instance is descended into so elements nested in
-    sub designs are still found.
+    Returns a tuple ``(ports, edge_directions, edge_footprints)``. ``ports`` is the list of :class:`Port`.
+    ``edge_directions`` maps each EdgePort number to its outward :class:`pya.DVector`, used to place that
+    port on the box edge. ``edge_footprints`` maps each EdgePort number to that launcher's global bounding
+    box (:class:`pya.DBox`), used to check the box edge still passes through the launcher. Launchers and
+    qubits are treated as leaves, every other instance is descended into so elements nested in sub designs
+    are still found.
     """
     layout = top_cell.layout()
     refpoint_layer = layout.layer(default_layers["refpoints"])
     ports = []
     edge_directions = {}
-    counter = [1]
+    edge_footprints = {}
+    counter = 1
 
     def visit(cell, trans):
+        nonlocal counter
         # Snapshot the instances first. Setting junction_type below regenerates a qubit cell, which would
         # invalidate a live instance iterator.
         for inst in list(cell.each_inst()):
             child = layout.cell(inst.cell_index)
             child_trans = trans * inst.dcplx_trans
             if _is_launcher(inst, child):
-                ports.append(EdgePort(counter[0], _launcher_signal_location(inst, child, child_trans)))
-                edge_directions[counter[0]] = _outward_direction(child_trans)
-                counter[0] += 1
+                ports.append(EdgePort(counter, _launcher_signal_location(inst, child, child_trans)))
+                edge_directions[counter] = _outward_direction(child_trans)
+                edge_footprints[counter] = child_trans * child.dbbox()
+                counter += 1
             elif _is_qubit(inst, child, layout):
                 if inst.pcell_declaration() is not None:
                     inst["junction_type"] = "Sim"
                     child = layout.cell(inst.cell_index)
                 squid = _squid_ports(child, child_trans, refpoint_layer)
                 if squid is not None:
-                    ports.append(InternalPort(counter[0], squid[0], squid[1]))
-                    counter[0] += 1
+                    ports.append(InternalPort(counter, squid[0], squid[1]))
+                    counter += 1
             else:
                 visit(child, child_trans)
 
     visit(top_cell, pya.DCplxTrans())
-    return ports, edge_directions
+    return ports, edge_directions, edge_footprints
 
 
-def simulation_box(top_cell, ports, edge_directions, margin=100.0):
+def simulation_box(top_cell, ports, edge_directions, edge_footprints, margin=100.0):
     """Return the simulation box as a :class:`pya.DBox` and place the edge ports on its rim.
 
     The box starts from the cell bounding box grown by ``margin``. Each side that faces a launcher is moved
-    to the outermost EdgePort on that side, then every EdgePort on that side is projected exactly onto the
-    edge. Manual placement is rarely pixel perfect, so this projection is what guarantees each EdgePort sits
-    on the box rim, which the Elmer export requires. A clear error is raised when the launcher orientations
-    leave no room for a valid box, for example a port facing right that ends up left of the opposite side.
+    to the EdgePort closest to the centre on that side, so the launcher nearest the design sits exactly on
+    the rim. Launchers further out then stick partially outside the box, which is fine as long as the rim
+    still crosses the launcher, so a point inside it lands on the box. Every EdgePort on a side is then
+    projected onto that side. Manual placement is rarely pixel perfect, so this projection is what
+    guarantees each EdgePort sits on the box rim, which the Elmer export requires.
+
+    A clear error is raised when the launcher positions do not admit a valid box: when a side has no room
+    against the opposite side, or when the rim cannot pass through a launcher because it sits too far out
+    relative to its neighbour on the same side.
 
     The ``signal_location`` of the affected EdgePorts is updated in place.
     """
@@ -189,20 +219,44 @@ def simulation_box(top_cell, ports, edge_directions, margin=100.0):
         else:
             sides["top" if direction.y > 0 else "bottom"].append(port)
 
+    # Move each side to the launcher closest to the centre, so that launcher sits on the rim and any
+    # launcher further out only pokes through it.
     if sides["left"]:
-        left = min(port.signal_location.x for port in sides["left"])
+        left = max(port.signal_location.x for port in sides["left"])
     if sides["right"]:
-        right = max(port.signal_location.x for port in sides["right"])
+        right = min(port.signal_location.x for port in sides["right"])
     if sides["bottom"]:
-        bottom = min(port.signal_location.y for port in sides["bottom"])
+        bottom = max(port.signal_location.y for port in sides["bottom"])
     if sides["top"]:
-        top = max(port.signal_location.y for port in sides["top"])
+        top = min(port.signal_location.y for port in sides["top"])
 
     if right - left <= 0 or top - bottom <= 0:
         raise ValueError(
             "Could not define a simulation box from the launcher positions. Check that the launchers point "
             "outward and sit at the edge of the design."
         )
+
+    # Each launcher must still be crossed by its box edge, otherwise it has no point on the rim to host the
+    # port. This rejects a launcher that sits too far out compared to its neighbours on the same side.
+    edges = {"left": left, "right": right, "bottom": bottom, "top": top}
+    for side in ("left", "right"):
+        for port in sides[side]:
+            footprint = edge_footprints.get(port.number)
+            if footprint is not None and not footprint.left - 1e-6 <= edges[side] <= footprint.right + 1e-6:
+                raise ValueError(
+                    "A launcher sits too far outside the box for the box edge to reach it. The launcher "
+                    "locations are incorrect: launchers on the same side should sit at a similar distance "
+                    "from the design."
+                )
+    for side in ("bottom", "top"):
+        for port in sides[side]:
+            footprint = edge_footprints.get(port.number)
+            if footprint is not None and not footprint.bottom - 1e-6 <= edges[side] <= footprint.top + 1e-6:
+                raise ValueError(
+                    "A launcher sits too far outside the box for the box edge to reach it. The launcher "
+                    "locations are incorrect: launchers on the same side should sit at a similar distance "
+                    "from the design."
+                )
 
     for port in sides["left"]:
         port.signal_location = pya.DPoint(left, port.signal_location.y)
@@ -217,36 +271,44 @@ def simulation_box(top_cell, ports, edge_directions, margin=100.0):
 
 
 def export_open_layout_to_elmer(
-    top_cell, path, *, name="gui_simulation", target_frequency=5.0, mesh_size=None, workflow=None, margin=100.0
+    top_cell,
+    path,
+    name="gui_simulation",
+    target_frequency=5.0,
+    mesh_size=None,
+    solution=None,
+    workflow=None,
+    margin=100.0,
 ):
     """Export the geometry in ``top_cell`` as an Elmer wave equation simulation.
 
     Args:
         top_cell: the top cell whose geometry is exported. The cell is modified, so the macro passes a copy.
-        path: directory the simulation files are written to.
+        path: directory the simulation files are written to. Must not already exist.
         name: simulation name, also the file name stem.
-        target_frequency: solver frequency in GHz.
-        mesh_size: Gmsh mesh size dictionary, defaults to :func:`default_mesh_size`.
+        target_frequency: solver frequency in GHz, used for the default solution.
+        mesh_size: Gmsh mesh size dictionary for the default solution, defaults to :func:`default_mesh_size`.
+        solution: Elmer solution object, defaults to :func:`default_wave_equation_solution` built from
+            ``target_frequency`` and ``mesh_size``.
         workflow: Elmer workflow dictionary, defaults to :func:`default_workflow`.
         margin: distance in micrometers added around the geometry on sides without a launcher.
 
     Returns:
         Path to the written simulation directory.
+
+    Raises:
+        FileExistsError: if ``path`` already exists, so an earlier export is not overwritten silently.
     """
-    ports, edge_directions = collect_ports(top_cell)
+    ports, edge_directions, edge_footprints = collect_ports(top_cell)
     if not edge_directions:
         raise ValueError("No launchers found in the layout, cannot place edge ports for the simulation.")
 
     path = Path(path)
-    path.mkdir(parents=True, exist_ok=True)
-    box = simulation_box(top_cell, ports, edge_directions, margin)
+    if path.exists():
+        raise FileExistsError(f"Simulation folder already exists: {path}. Remove it or choose another path.")
+    path.mkdir(parents=True)
+    box = simulation_box(top_cell, ports, edge_directions, edge_footprints, margin)
     simulation = Simulation.from_cell(top_cell, name=name, box=box, ports=ports)
-    solution = ElmerVectorHelmholtzSolution(
-        mesh_size=default_mesh_size() if mesh_size is None else mesh_size,
-        frequency=target_frequency,
-        # Use first order basis since the model is very large
-        quadratic_approximation=False,
-        linear_system_method="zmumps",
-        use_multigrid_solver=False,
-    )
+    if solution is None:
+        solution = default_wave_equation_solution(target_frequency, mesh_size)
     return export_elmer([(simulation, solution)], path, workflow=default_workflow() if workflow is None else workflow)

--- a/klayout_package/python/kqcircuits/simulations/simulation.py
+++ b/klayout_package/python/kqcircuits/simulations/simulation.py
@@ -275,7 +275,7 @@ class Simulation:
         docstring="This field may be used to store 'virtual' parameters useful for your simulations",
     )
 
-    def __init__(self, layout, **kwargs):
+    def __init__(self, layout, ports=None, **kwargs):
         """Initialize a Simulation.
 
         The initializer parses parameters, creates a top cell, and then calls `self.build` to create
@@ -284,6 +284,11 @@ class Simulation:
 
         Args:
             layout: the layout on which to create the simulation
+            ports: optional list of `Port` to assign to the simulation. This is meant for simulations
+                created with an existing cell where `build` does not add ports itself, such as
+                `Simulation.from_cell`. When given, the list replaces `self.ports` after `build` has
+                run and before the simulation layers are created. Leave as None for subclasses that
+                populate `self.ports` inside `build`.
 
         Keyword arguments:
             `**kwargs`:
@@ -325,11 +330,13 @@ class Simulation:
 
         self.layers = {}
         self.build()
+        if ports is not None:
+            self.ports = ports
         self.create_simulation_layers()
         self.warn_of_small_shapes()
 
     @classmethod
-    def from_cell(cls, cell, margin=300, grid_size=1, **kwargs):
+    def from_cell(cls, cell, margin=300, grid_size=1, ports=None, **kwargs):
         """Create a Simulation from an existing cell.
 
         Arguments:
@@ -338,6 +345,8 @@ class Simulation:
                 box of the cell If the `box` keyword argument is given, margin is ignored.
             grid_size: size of the simulation box will be rounded to this resolution
                 If the `box` keyword argument is given, grid_size is ignored.
+            ports: optional list of `Port` to assign to the simulation. Pass this when the ports are
+                determined from the existing geometry, since the default `build` does not add ports.
             `**kwargs`: any simulation parameters passed
 
         Returns:
@@ -354,7 +363,7 @@ class Simulation:
                 box.top = round(box.top / grid_size) * grid_size
             extra_kwargs["box"] = box
 
-        return cls(cell.layout(), cell=cell, **kwargs, **extra_kwargs)
+        return cls(cell.layout(), cell=cell, ports=ports, **kwargs, **extra_kwargs)
 
     @abc.abstractmethod
     def build(self):

--- a/klayout_package/python/scripts/macros/export/export_elmer.lym
+++ b/klayout_package/python/scripts/macros/export/export_elmer.lym
@@ -15,7 +15,7 @@
  <interpreter>python</interpreter>
  <dsl-interpreter-name/>
  <text># This code is part of KQCircuits
-# Copyright (C) 2025 IQM Finland Oy
+# Copyright (C) 2026 IQM Finland Oy
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
@@ -40,7 +40,11 @@ edge ports and internal ports, works out the simulation box, and writes the Elme
 opens in a new tab so the original design is left untouched.
 """
 
+import shutil
+from pathlib import Path
+
 from kqcircuits.klayout_view import KLayoutView
+from kqcircuits.pya_resolver import pya
 from kqcircuits.simulations.export.elmer.gui_layout_export import (
     export_open_layout_to_elmer,
     default_mesh_size,
@@ -56,25 +60,44 @@ margin = 100.0  # extra space in micrometers on sides without a launcher
 mesh_size = default_mesh_size()  # Gmsh mesh size, refined at the metal edges
 workflow = default_workflow()  # Elmer pipeline steps
 
-# Copy the active design into a new layout so the geometry the user drew is left intact. The export adds
-# simulation layers, and those should not pollute the original view. Layout.assign copies the cells with
-# their PCell data kept, which Cell.copy_tree across layouts would drop. The PCell data is needed to find
-# the launchers and qubits and to switch the qubit junctions to the Sim type.
-source_view = KLayoutView(current=True)
-source_name = source_view.active_cell.name
-preview = KLayoutView()
-preview.layout.assign(source_view.layout)
-copy = [cell for cell in preview.layout.top_cells() if cell.name == source_name][0]
-preview.focus(copy)
+# If the output folder already exists, ask before overwriting so an earlier export is not lost. On abort
+# leave everything unchanged and do not even open a preview tab.
+overwrite = True
+if Path(path).exists():
+    overwrite = (
+        pya.MessageBox.warning(
+            "Simulation folder exists",
+            f"The folder\n{path}\nalready exists.\n\nDelete it and export again?",
+            pya.MessageBox.Yes + pya.MessageBox.No,
+        )
+        == pya.MessageBox.Yes
+    )
+    if overwrite:
+        shutil.rmtree(path)
 
-path = export_open_layout_to_elmer(
-    copy,
-    path,
-    name=name,
-    target_frequency=target_frequency,
-    mesh_size=mesh_size,
-    workflow=workflow,
-    margin=margin,
-)
-print(f"Exported Elmer simulation to {path}")</text>
+if overwrite:
+    # Copy the active design into a new layout so the geometry the user drew is left intact. The export adds
+    # simulation layers, and those should not pollute the original view. Layout.assign copies the cells with
+    # their PCell data kept, which Cell.copy_tree across layouts would drop. The PCell data is needed to find
+    # the launchers and qubits and to switch the qubit junctions to the Sim type.
+    source_view = KLayoutView(current=True)
+    source_name = source_view.active_cell.name
+    preview = KLayoutView()
+    preview.layout.assign(source_view.layout)
+    copy = [cell for cell in preview.layout.top_cells() if cell.name == source_name][0]
+    preview.focus(copy)
+
+    path = export_open_layout_to_elmer(
+        copy,
+        path,
+        name=name,
+        target_frequency=target_frequency,
+        mesh_size=mesh_size,
+        workflow=workflow,
+        margin=margin,
+    )
+    preview.layout_view.add_missing_layers()
+    print(f"Exported Elmer simulation to {path}")
+else:
+    print(f"Export aborted, {path} left unchanged.")</text>
 </klayout-macro>

--- a/klayout_package/python/scripts/macros/export/export_elmer.lym
+++ b/klayout_package/python/scripts/macros/export/export_elmer.lym
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<klayout-macro>
+ <description>Current view to Elmer</description>
+ <version/>
+ <category>pymacros</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <shortcut/>
+ <show-in-menu>false</show-in-menu>
+ <group-name>Export</group-name>
+ <menu-path/>
+ <interpreter>python</interpreter>
+ <dsl-interpreter-name/>
+ <text># This code is part of KQCircuits
+# Copyright (C) 2025 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+"""Export the layout currently open in KLayout as an Elmer wave equation simulation.
+
+Draw a design in the GUI using KQC library elements, with launchers at the chip edge and qubits placed in the
+layout, then run this macro with that design as the top cell. The macro finds the launchers and qubits, places
+edge ports and internal ports, works out the simulation box, and writes the Elmer simulation files. The result
+opens in a new tab so the original design is left untouched.
+"""
+
+from kqcircuits.klayout_view import KLayoutView
+from kqcircuits.simulations.export.elmer.gui_layout_export import (
+    export_open_layout_to_elmer,
+    default_mesh_size,
+    default_workflow,
+)
+from kqcircuits.defaults import TMP_PATH
+
+# Configuration. Adjust these to your simulation.
+name = "gui_simulation"  # simulation name and file name stem
+path = TMP_PATH.joinpath(name + "_elmer")  # output directory
+target_frequency = 5.0  # solver frequency in GHz
+margin = 100.0  # extra space in micrometers on sides without a launcher
+mesh_size = default_mesh_size()  # Gmsh mesh size, refined at the metal edges
+workflow = default_workflow()  # Elmer pipeline steps
+
+# Copy the active design into a new layout so the geometry the user drew is left intact. The export adds
+# simulation layers, and those should not pollute the original view. Layout.assign copies the cells with
+# their PCell data kept, which Cell.copy_tree across layouts would drop. The PCell data is needed to find
+# the launchers and qubits and to switch the qubit junctions to the Sim type.
+source_view = KLayoutView(current=True)
+source_name = source_view.active_cell.name
+preview = KLayoutView()
+preview.layout.assign(source_view.layout)
+copy = [cell for cell in preview.layout.top_cells() if cell.name == source_name][0]
+preview.focus(copy)
+
+path = export_open_layout_to_elmer(
+    copy,
+    path,
+    name=name,
+    target_frequency=target_frequency,
+    mesh_size=mesh_size,
+    workflow=workflow,
+    margin=margin,
+)
+print(f"Exported Elmer simulation to {path}")</text>
+</klayout-macro>

--- a/tests/simulations/test_gui_layout_export.py
+++ b/tests/simulations/test_gui_layout_export.py
@@ -1,0 +1,135 @@
+# This code is part of KQCircuits
+# Copyright (C) 2025 IQM Finland Oy
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see
+# https://www.gnu.org/licenses/gpl-3.0.html.
+#
+# The software distribution should follow IQM trademark policy for open-source software
+# (meetiqm.com/iqm-open-source-trademark-policy). IQM welcomes contributions to the code.
+# Please see our contribution agreements for individuals (meetiqm.com/iqm-individual-contributor-license-agreement)
+# and organizations (meetiqm.com/iqm-organization-contributor-license-agreement).
+
+import json
+
+import pytest
+
+from kqcircuits.pya_resolver import pya
+from kqcircuits.elements.launcher import Launcher
+from kqcircuits.qubits.swissmon import Swissmon
+from kqcircuits.simulations.port import EdgePort, InternalPort
+from kqcircuits.simulations.export.elmer.gui_layout_export import (
+    collect_ports,
+    simulation_box,
+    export_open_layout_to_elmer,
+)
+
+
+def _design_with_two_launchers_and_qubit():
+    """Build a small layout with two launchers facing left and right and one qubit in the middle.
+
+    Returns the layout and its top cell. The caller keeps a reference to the layout so it is not destroyed.
+    """
+    layout = pya.Layout()
+    top = layout.create_cell("Top")
+    west = Launcher.create(layout, s=300, l=300)
+    top.insert(pya.DCellInstArray(west.cell_index(), pya.DCplxTrans(1, 180, False, 500.0, 1500.0)))
+    east = Launcher.create(layout, s=300, l=300)
+    top.insert(pya.DCellInstArray(east.cell_index(), pya.DCplxTrans(1, 0, False, 2500.0, 1500.0)))
+    qubit = Swissmon.create(layout)
+    top.insert(pya.DCellInstArray(qubit.cell_index(), pya.DCplxTrans(1, 0, False, 1500.0, 1500.0)))
+    return layout, top
+
+
+def test_collect_ports_finds_launchers_and_qubit():
+    layout, top = _design_with_two_launchers_and_qubit()
+    ports, edge_directions = collect_ports(top)
+
+    edge_ports = [p for p in ports if isinstance(p, EdgePort)]
+    internal_ports = [p for p in ports if isinstance(p, InternalPort)]
+    assert len(edge_ports) == 2
+    assert len(internal_ports) == 1
+    # Each EdgePort has a recorded outward direction, the InternalPort does not.
+    assert set(edge_directions) == {p.number for p in edge_ports}
+    # The qubit junction provides a ground location for its internal port.
+    assert hasattr(internal_ports[0], "ground_location")
+    assert layout.cells() > 0
+
+
+def test_edge_ports_land_on_box_edges():
+    layout, top = _design_with_two_launchers_and_qubit()
+    ports, edge_directions = collect_ports(top)
+    box = simulation_box(top, ports, edge_directions, margin=100.0)
+    assert layout.cells() > 0
+
+    for port in ports:
+        direction = edge_directions.get(port.number)
+        if direction is None:
+            continue
+        location = port.signal_location
+        if abs(direction.x) >= abs(direction.y):
+            edge = box.right if direction.x > 0 else box.left
+            assert location.x == pytest.approx(edge, abs=1e-6)
+        else:
+            edge = box.top if direction.y > 0 else box.bottom
+            assert location.y == pytest.approx(edge, abs=1e-6)
+
+
+def test_simulation_box_projects_ports_onto_edges_including_zero():
+    # A left edge at x=0 used to be dropped as a falsy value, and ports on one side that are slightly
+    # misaligned must still end up on a single straight edge.
+    layout = pya.Layout()
+    top = layout.create_cell("Top")
+    top.shapes(layout.layer(1, 0)).insert(pya.DBox(-500.0, -500.0, 500.0, 500.0))
+
+    right_high = EdgePort(1, pya.DPoint(480.0, 100.0))
+    right_low = EdgePort(2, pya.DPoint(495.0, -100.0))
+    left_at_zero = EdgePort(3, pya.DPoint(0.0, 250.0))
+    directions = {1: pya.DVector(1, 0), 2: pya.DVector(1, 0), 3: pya.DVector(-1, 0)}
+
+    box = simulation_box(top, [right_high, right_low, left_at_zero], directions, margin=100.0)
+
+    # The left edge follows the launcher at x=0, it does not fall back to the bounding box minus margin.
+    assert box.left == pytest.approx(0.0)
+    assert left_at_zero.signal_location.x == pytest.approx(0.0)
+    # The right edge is the outermost right port, and both right ports are projected onto it.
+    assert box.right == pytest.approx(495.0)
+    assert right_high.signal_location.x == pytest.approx(495.0)
+    assert right_low.signal_location.x == pytest.approx(495.0)
+
+
+def test_layout_without_launchers_has_no_edge_ports():
+    layout = pya.Layout()
+    top = layout.create_cell("Top")
+    qubit = Swissmon.create(layout)
+    top.insert(pya.DCellInstArray(qubit.cell_index(), pya.DCplxTrans(1, 0, False, 0.0, 0.0)))
+
+    _, edge_directions = collect_ports(top)
+    assert not edge_directions
+
+
+def test_export_on_copied_layout_keeps_qubit_internal_port(tmp_path):
+    # The macro copies the active layout into a new view before exporting, so the qubit must still be found
+    # and switched to a Sim junction on the copy. A qubit drawn with the default Manhattan junction has no
+    # squid ports, so the export has to convert it. Layout.assign keeps the PCell data that this relies on.
+    layout, top = _design_with_two_launchers_and_qubit()
+    copy_layout = pya.Layout()
+    copy_layout.assign(layout)
+    copy_top = [cell for cell in copy_layout.top_cells() if cell.name == top.name][0]
+
+    no_run = {"run_gmsh_gui": False, "run_elmergrid": False, "run_elmer": False, "run_paraview": False}
+    out_dir = tmp_path / "sim"
+    export_open_layout_to_elmer(copy_top, out_dir, name="sim", workflow=no_run)
+
+    data = json.loads((out_dir / "sim.json").read_text())
+    edge = [p for p in data["ports"] if p["type"] == "EdgePort"]
+    internal = [p for p in data["ports"] if p["type"] == "InternalPort"]
+    assert len(edge) == 2
+    assert len(internal) == 1
+    assert (out_dir / "sim.gds").exists()

--- a/tests/simulations/test_gui_layout_export.py
+++ b/tests/simulations/test_gui_layout_export.py
@@ -1,5 +1,5 @@
 # This code is part of KQCircuits
-# Copyright (C) 2025 IQM Finland Oy
+# Copyright (C) 2026 IQM Finland Oy
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
@@ -47,70 +47,99 @@ def _design_with_two_launchers_and_qubit():
     return layout, top
 
 
+def _cell_with_bbox(left, bottom, right, top_):
+    """Return a layout and a top cell whose bounding box is the given rectangle."""
+    layout = pya.Layout()
+    top = layout.create_cell("Top")
+    top.shapes(layout.layer(1, 0)).insert(pya.DBox(left, bottom, right, top_))
+    return layout, top
+
+
 def test_collect_ports_finds_launchers_and_qubit():
+    """collect_ports returns the launchers, the qubit port, their directions and footprints."""
     layout, top = _design_with_two_launchers_and_qubit()
-    ports, edge_directions = collect_ports(top)
+    ports, edge_directions, edge_footprints = collect_ports(top)
 
     edge_ports = [p for p in ports if isinstance(p, EdgePort)]
     internal_ports = [p for p in ports if isinstance(p, InternalPort)]
     assert len(edge_ports) == 2
     assert len(internal_ports) == 1
-    # Each EdgePort has a recorded outward direction, the InternalPort does not.
+    # Each EdgePort has a recorded outward direction and a footprint, the InternalPort does not.
     assert set(edge_directions) == {p.number for p in edge_ports}
+    assert set(edge_footprints) == {p.number for p in edge_ports}
+    assert all(isinstance(box, pya.DBox) for box in edge_footprints.values())
     # The qubit junction provides a ground location for its internal port.
     assert hasattr(internal_ports[0], "ground_location")
     assert layout.cells() > 0
 
 
 def test_edge_ports_land_on_box_edges():
+    """The two launcher signals land on the box rims and the qubit signal stays in the middle."""
     layout, top = _design_with_two_launchers_and_qubit()
-    ports, edge_directions = collect_ports(top)
-    box = simulation_box(top, ports, edge_directions, margin=100.0)
+    ports, edge_directions, edge_footprints = collect_ports(top)
+    box = simulation_box(top, ports, edge_directions, edge_footprints, margin=100.0)
     assert layout.cells() > 0
 
-    for port in ports:
-        direction = edge_directions.get(port.number)
-        if direction is None:
-            continue
-        location = port.signal_location
-        if abs(direction.x) >= abs(direction.y):
-            edge = box.right if direction.x > 0 else box.left
-            assert location.x == pytest.approx(edge, abs=1e-6)
-        else:
-            edge = box.top if direction.y > 0 else box.bottom
-            assert location.y == pytest.approx(edge, abs=1e-6)
+    qubit_x = next(p.signal_location.x for p in ports if p.number not in edge_directions)
+    # One signal on the left rim, one on the right rim, the qubit port in the middle.
+    assert {p.signal_location.x for p in ports} == {box.left, box.right, qubit_x}
 
 
-def test_simulation_box_projects_ports_onto_edges_including_zero():
-    # A left edge at x=0 used to be dropped as a falsy value, and ports on one side that are slightly
-    # misaligned must still end up on a single straight edge.
-    layout = pya.Layout()
-    top = layout.create_cell("Top")
-    top.shapes(layout.layer(1, 0)).insert(pya.DBox(-500.0, -500.0, 500.0, 500.0))
+def test_simulation_box_follows_inner_launcher_and_keeps_outer_on_rim():
+    """Use case 1: with a slight shift the box edge follows the launcher nearer the centre.
 
-    right_high = EdgePort(1, pya.DPoint(480.0, 100.0))
-    right_low = EdgePort(2, pya.DPoint(495.0, -100.0))
+    The outer launcher is left partially outside the box, but the rim still crosses its footprint so it
+    keeps a point on the box. A left launcher placed at x=0 also checks that a zero edge is not dropped.
+    """
+    layout, top = _cell_with_bbox(-1000.0, -1000.0, 1000.0, 1000.0)
+    assert layout.cells() > 0
+
+    inner_right = EdgePort(1, pya.DPoint(1000.0, 200.0))
+    outer_right = EdgePort(2, pya.DPoint(1100.0, -200.0))
     left_at_zero = EdgePort(3, pya.DPoint(0.0, 250.0))
     directions = {1: pya.DVector(1, 0), 2: pya.DVector(1, 0), 3: pya.DVector(-1, 0)}
+    footprints = {
+        1: pya.DBox(700.0, 100.0, 1050.0, 300.0),
+        2: pya.DBox(950.0, -300.0, 1150.0, -100.0),  # reaches back across x=1000
+        3: pya.DBox(-50.0, 150.0, 200.0, 350.0),  # crosses x=0
+    }
 
-    box = simulation_box(top, [right_high, right_low, left_at_zero], directions, margin=100.0)
+    box = simulation_box(top, [inner_right, outer_right, left_at_zero], directions, footprints, margin=100.0)
 
-    # The left edge follows the launcher at x=0, it does not fall back to the bounding box minus margin.
+    # The right edge follows the inner launcher, not the outer one, and the left edge keeps the x=0 launcher.
+    assert box.right == pytest.approx(1000.0)
     assert box.left == pytest.approx(0.0)
+    # Both right ports are projected onto the inner edge, the left port onto x=0.
+    assert inner_right.signal_location.x == pytest.approx(1000.0)
+    assert outer_right.signal_location.x == pytest.approx(1000.0)
     assert left_at_zero.signal_location.x == pytest.approx(0.0)
-    # The right edge is the outermost right port, and both right ports are projected onto it.
-    assert box.right == pytest.approx(495.0)
-    assert right_high.signal_location.x == pytest.approx(495.0)
-    assert right_low.signal_location.x == pytest.approx(495.0)
+
+
+def test_simulation_box_raises_when_launcher_too_far_out():
+    """Use case 2: a launcher so far out that the rim cannot cross its footprint is rejected."""
+    layout, top = _cell_with_bbox(-1000.0, -1000.0, 1000.0, 1000.0)
+    assert layout.cells() > 0
+
+    inner_right = EdgePort(1, pya.DPoint(1000.0, 200.0))
+    far_right = EdgePort(2, pya.DPoint(1600.0, -200.0))
+    directions = {1: pya.DVector(1, 0), 2: pya.DVector(1, 0)}
+    footprints = {
+        1: pya.DBox(700.0, 100.0, 1050.0, 300.0),
+        2: pya.DBox(1450.0, -300.0, 1650.0, -100.0),  # does not reach back to x=1000
+    }
+
+    with pytest.raises(ValueError):
+        simulation_box(top, [inner_right, far_right], directions, footprints, margin=100.0)
 
 
 def test_layout_without_launchers_has_no_edge_ports():
+    """A layout with only a qubit yields no edge ports or directions."""
     layout = pya.Layout()
     top = layout.create_cell("Top")
     qubit = Swissmon.create(layout)
     top.insert(pya.DCellInstArray(qubit.cell_index(), pya.DCplxTrans(1, 0, False, 0.0, 0.0)))
 
-    _, edge_directions = collect_ports(top)
+    _, edge_directions, _ = collect_ports(top)
     assert not edge_directions
 
 
@@ -133,3 +162,16 @@ def test_export_on_copied_layout_keeps_qubit_internal_port(tmp_path):
     assert len(edge) == 2
     assert len(internal) == 1
     assert (out_dir / "sim.gds").exists()
+
+
+def test_export_raises_when_folder_exists(tmp_path):
+    """The library refuses to overwrite an existing output folder."""
+    layout, top = _design_with_two_launchers_and_qubit()
+    copy_layout = pya.Layout()
+    copy_layout.assign(layout)
+    copy_top = [cell for cell in copy_layout.top_cells() if cell.name == top.name][0]
+
+    out_dir = tmp_path / "sim"
+    out_dir.mkdir()
+    with pytest.raises(FileExistsError):
+        export_open_layout_to_elmer(copy_top, out_dir, name="sim")

--- a/tests/simulations/test_gui_layout_export.py
+++ b/tests/simulations/test_gui_layout_export.py
@@ -47,11 +47,11 @@ def _design_with_two_launchers_and_qubit():
     return layout, top
 
 
-def _cell_with_bbox(left, bottom, right, top_):
+def _cell_with_bbox(x1, y1, x2, y2):
     """Return a layout and a top cell whose bounding box is the given rectangle."""
     layout = pya.Layout()
     top = layout.create_cell("Top")
-    top.shapes(layout.layer(1, 0)).insert(pya.DBox(left, bottom, right, top_))
+    top.shapes(layout.layer(1, 0)).insert(pya.DBox(x1, y1, x2, y2))
     return layout, top
 
 
@@ -132,6 +132,60 @@ def test_simulation_box_raises_when_launcher_too_far_out():
         simulation_box(top, [inner_right, far_right], directions, footprints, margin=100.0)
 
 
+def test_simulation_box_places_vertical_launcher_on_box_rim():
+    """A south launcher inside the horizontal span lands on the bottom rim, so the box is consistent.
+
+    The left and right edges are set by the west and east launchers. A south launcher whose footprint sits
+    between them shares that box: its port is projected onto the bottom rim at its own x.
+    """
+    layout, top = _cell_with_bbox(-1000.0, -1000.0, 1000.0, 1000.0)
+    assert layout.cells() > 0
+
+    west = EdgePort(1, pya.DPoint(-1000.0, 0.0))
+    east = EdgePort(2, pya.DPoint(1000.0, 0.0))
+    south = EdgePort(3, pya.DPoint(300.0, -1000.0))
+    directions = {1: pya.DVector(-1, 0), 2: pya.DVector(1, 0), 3: pya.DVector(0, -1)}
+    footprints = {
+        1: pya.DBox(-1050.0, -100.0, -800.0, 100.0),
+        2: pya.DBox(800.0, -100.0, 1050.0, 100.0),
+        3: pya.DBox(200.0, -1050.0, 400.0, -950.0),
+    }
+
+    box = simulation_box(top, [west, east, south], directions, footprints, margin=100.0)
+
+    assert box.left == pytest.approx(-1000.0)
+    assert box.right == pytest.approx(1000.0)
+    assert box.bottom == pytest.approx(-1000.0)
+    # The south port sits on the bottom rim, keeping its own x which is inside the horizontal span.
+    assert south.signal_location.y == pytest.approx(box.bottom)
+    assert south.signal_location.x == pytest.approx(300.0)
+
+
+def test_simulation_box_raises_when_launcher_outside_perpendicular_span():
+    """A south launcher sitting outside the horizontal span cannot share a consistent box, so it is rejected.
+
+    The west and east launchers fix the left and right edges. A south launcher placed to the right of the
+    east launcher has no point on the finite bottom rim, the box corner cuts it off. The old code projected
+    its port outside the box instead of complaining, so this guards that the launchers are reconciled across
+    both axes.
+    """
+    layout, top = _cell_with_bbox(-1000.0, -1000.0, 1000.0, 1000.0)
+    assert layout.cells() > 0
+
+    west = EdgePort(1, pya.DPoint(-1000.0, 0.0))
+    east = EdgePort(2, pya.DPoint(1000.0, 0.0))
+    south = EdgePort(3, pya.DPoint(2000.0, -1000.0))
+    directions = {1: pya.DVector(-1, 0), 2: pya.DVector(1, 0), 3: pya.DVector(0, -1)}
+    footprints = {
+        1: pya.DBox(-1050.0, -100.0, -800.0, 100.0),
+        2: pya.DBox(800.0, -100.0, 1050.0, 100.0),
+        3: pya.DBox(1900.0, -1050.0, 2100.0, -950.0),  # entirely past the right edge
+    }
+
+    with pytest.raises(ValueError):
+        simulation_box(top, [west, east, south], directions, footprints, margin=100.0)
+
+
 def test_layout_without_launchers_has_no_edge_ports():
     """A layout with only a qubit yields no edge ports or directions."""
     layout = pya.Layout()
@@ -167,11 +221,9 @@ def test_export_on_copied_layout_keeps_qubit_internal_port(tmp_path):
 def test_export_raises_when_folder_exists(tmp_path):
     """The library refuses to overwrite an existing output folder."""
     layout, top = _design_with_two_launchers_and_qubit()
-    copy_layout = pya.Layout()
-    copy_layout.assign(layout)
-    copy_top = [cell for cell in copy_layout.top_cells() if cell.name == top.name][0]
+    assert layout.cells() > 0
 
     out_dir = tmp_path / "sim"
     out_dir.mkdir()
     with pytest.raises(FileExistsError):
-        export_open_layout_to_elmer(copy_top, out_dir, name="sim")
+        export_open_layout_to_elmer(top, out_dir, name="sim")


### PR DESCRIPTION
Closes #122.

Implements the design from issue 122 (Elmer export for layouts drawn in the KLayout GUI).

This adds a macro that takes the geometry currently open in KLayout and exports it as an Elmer wave equation simulation, the same kind of output the existing Python simulation scripts produce.

What it does, following the design in the issue:
- Walks the cell hierarchy of the active design, compounding the instance transforms down the tree.
- Finds Launcher elements and places an EdgePort at each launcher pad edge, at local (s + l, 0).
- Finds qubits, sets their junction_type to Sim and places an InternalPort across the junction from the squid_port_squid_a and squid_port_squid_b reference points.
- Works out the simulation box from the design bounding box and the launcher positions, then projects each EdgePort onto its box edge so the edge ports sit on the rim. It raises a clear error when the launcher orientations leave no room for a valid box.
- Builds the simulation with Simulation.from_cell and exports it with export_elmer and an ElmerVectorHelmholtzSolution.
- Runs on a copy in a new tab so the design you drew is left untouched.

The macro is at scripts/macros/export/export_elmer.lym and mirrors the existing export_ansys.lym. The scraping, port placement and box logic live in a new module simulations/export/elmer/gui_layout_export.py so they can be tested without the GUI. Elements are identified from live PCell data and fall back to the cell name, so the export also works on a flattened layout loaded from a file.

Simulation.from_cell and Simulation.__init__ gain an optional ports argument. The default build does not add ports, so this is the way to attach the ports worked out from the existing geometry. The default is None and existing simulation subclasses are unaffected.

Verification. I do not have Elmer installed, so following the issue I checked the export side only. Running the export headless on the gui_design.oas you attached produces 2 edge ports and 2 internal ports with the gds, json and simulation.sh files. The edge ports land on the box edges. I also ran it on a small design built from live PCell launchers and a Swissmon qubit to exercise the PCell path and the junction_type change. The full test suite passes (473 passed, 11 skipped), black is clean and pylint is 10/10. I added four tests under tests/simulations/test_gui_layout_export.py.

I used the gui_design.oas case you attached, so you can run the macro in the GUI and check the Elmer side. One thing I would like your read on. When launchers on the same side are slightly misaligned I project the edge ports onto a single edge at the outermost launcher. That matches your note that the port can sit a bit off the opening. Let me know if you would rather snap to a different reference.

This change was implemented with substantial help from Claude (Anthropic), which wrote the macro, the module and the tests from the design you laid out in the issue. It was verified locally before submitting: the full test suite (473 passed, 11 skipped), black, pylint 10/10 and the two headless export runs described above. The design choices are documented in the PR for review.
